### PR TITLE
Improve BaseOrderUtils.setExactOrderPrice

### DIFF
--- a/contracts/errors/Errors.sol
+++ b/contracts/errors/Errors.sol
@@ -128,7 +128,12 @@ library Errors {
     // BaseOrderUtils errors
     error EmptyOrder();
     error UnsupportedOrderType();
-    error InvalidOrderPrices(
+    error InvalidLimitOrderPrices(
+        uint256 primaryPrice,
+        uint256 triggerPrice,
+        bool shouldValidateSmallerPrimaryPrice
+    );
+    error InvalidStopLossOrderPrices(
         uint256 primaryPrice,
         uint256 secondaryPrice,
         uint256 triggerPrice,

--- a/test/exchange/FundingFees.ts
+++ b/test/exchange/FundingFees.ts
@@ -203,8 +203,10 @@ describe("Exchange.FundingFees", () => {
     expect(await dataStore.getInt(keys.fundingAmountPerSizeKey(ethUsdMarket.marketToken, wnt.address, false))).eq(
       "-16128039999999990000000000"
     ); // -0.000000016128039999 ETH, -0.00008064019 USD
-    expect(await dataStore.getInt(keys.fundingAmountPerSizeKey(ethUsdMarket.marketToken, usdc.address, true))).eq(
-      "-80642700000000000"
+    expectWithinRange(
+      await dataStore.getInt(keys.fundingAmountPerSizeKey(ethUsdMarket.marketToken, usdc.address, true)),
+      "-80642700000000000",
+      "1000000000000"
     ); // -0.00008 USD
     expect(await dataStore.getInt(keys.fundingAmountPerSizeKey(ethUsdMarket.marketToken, usdc.address, false))).eq(
       "40320390000000000" // 0.00004 USD

--- a/utils/error.ts
+++ b/utils/error.ts
@@ -2,6 +2,9 @@ import { getEventDataValue } from "./event";
 
 import Errors from "../artifacts/contracts/errors/Errors.sol/Errors.json";
 
+export const errorsInterface = new ethers.utils.Interface(Errors.abi);
+export const errorsContract = new ethers.Contract(ethers.constants.AddressZero, Errors.abi);
+
 export function getErrorString(error) {
   return JSON.stringify({
     name: error.name,
@@ -15,9 +18,8 @@ export function getCancellationReason({ logs, eventName }) {
     return;
   }
 
-  const errors = new ethers.utils.Interface(Errors.abi);
   try {
-    const reason = errors.parseError(reasonBytes);
+    const reason = errorsInterface.parseError(reasonBytes);
     return reason;
   } catch (e) {
     throw new Error(`Could not parse errorBytes ${reasonBytes}`);

--- a/utils/order.ts
+++ b/utils/order.ts
@@ -114,16 +114,7 @@ export async function createOrder(fixture, overrides) {
 export async function executeOrder(fixture, overrides = {}) {
   const { wnt, usdc } = fixture.contracts;
   const { gasUsageLabel, oracleBlockNumberOffset } = overrides;
-  const {
-    reader,
-    dataStore,
-    orderHandler,
-    baseOrderUtils,
-    increaseOrderUtils,
-    increasePositionUtils,
-    positionUtils,
-    marketUtils,
-  } = fixture.contracts;
+  const { reader, dataStore, orderHandler } = fixture.contracts;
   const tokens = overrides.tokens || [wnt.address, usdc.address];
   const precisions = overrides.precisions || [8, 18];
   const minPrices = overrides.minPrices || [expandDecimals(5000, 4), expandDecimals(1, 6)];


### PR DESCRIPTION
Limit orders should be executable with only one primary price for the index token, as long as the price occurs after the order was created

Stop-loss orders still require a primary price and a secondary price for the index token