### PR TITLE
Improve oracle reliability

### DIFF
--- a/config/oracle.ts
+++ b/config/oracle.ts
@@ -4,6 +4,7 @@ import { TOKEN_ORACLE_TYPES } from "../utils/oracle";
 type OracleRealPriceFeed = {
   address: string;
   decimals: number;
+  heartbeatDuration: number;
   deploy?: never;
   initPrice?: never;
 };
@@ -11,6 +12,7 @@ type OracleRealPriceFeed = {
 type OracleTestPriceFeed = {
   address?: never;
   decimals: number;
+  heartbeatDuration: number;
   deploy: true;
   initPrice: string;
 };
@@ -55,6 +57,7 @@ export default async function (hre: HardhatRuntimeEnvironment): Promise<OracleCo
         USDC: {
           priceFeed: {
             decimals: 8,
+            heartbeatDuration: 24 * 60 * 60,
             deploy: true,
             initPrice: "100000000",
           },
@@ -75,6 +78,7 @@ export default async function (hre: HardhatRuntimeEnvironment): Promise<OracleCo
             // this is USDT price feed, there is no USDC feed on Avalanche Fuji
             address: "0x7898AcCC83587C3C55116c5230C17a6Cd9C71bad",
             decimals: 8,
+            heartbeatDuration: 24 * 60 * 60,
           },
         },
       },

--- a/contracts/config/Config.sol
+++ b/contracts/config/Config.sol
@@ -253,6 +253,8 @@ contract Config is ReentrancyGuard, RoleModule, BasicMulticall {
         allowedBaseKeys[Keys.BORROWING_FACTOR] = true;
 
         allowedBaseKeys[Keys.CLAIMABLE_COLLATERAL_FACTOR] = true;
+
+        allowedBaseKeys[Keys.PRICE_FEED_HEARTBEAT_DURATION] = true;
     }
 
     // @dev validate that the baseKey is allowed to be used

--- a/contracts/config/Timelock.sol
+++ b/contracts/config/Timelock.sol
@@ -185,12 +185,14 @@ contract Timelock is ReentrancyGuard, RoleModule, BasicMulticall {
         address token,
         address priceFeed,
         uint256 priceFeedMultiplier,
+        uint256 priceFeedHeartbeatDuration,
         uint256 stablePrice
     ) external onlyTimelockAdmin nonReentrant {
         bytes32 actionKey = _setPriceFeedActionKey(
             token,
             priceFeed,
             priceFeedMultiplier,
+            priceFeedHeartbeatDuration,
             stablePrice
         );
 
@@ -200,9 +202,10 @@ contract Timelock is ReentrancyGuard, RoleModule, BasicMulticall {
         eventData.addressItems.initItems(2);
         eventData.addressItems.setItem(0, "token", token);
         eventData.addressItems.setItem(1, "priceFeed", priceFeed);
-        eventData.uintItems.initItems(2);
+        eventData.uintItems.initItems(3);
         eventData.uintItems.setItem(0, "priceFeedMultiplier", priceFeedMultiplier);
-        eventData.uintItems.setItem(1, "stablePrice", stablePrice);
+        eventData.uintItems.setItem(1, "priceFeedHeartbeatDuration", priceFeedHeartbeatDuration);
+        eventData.uintItems.setItem(2, "stablePrice", stablePrice);
         eventEmitter.emitEventLog1(
             "SignalSetPriceFeed",
             actionKey,
@@ -219,12 +222,14 @@ contract Timelock is ReentrancyGuard, RoleModule, BasicMulticall {
         address token,
         address priceFeed,
         uint256 priceFeedMultiplier,
+        uint256 priceFeedHeartbeatDuration,
         uint256 stablePrice
     ) external onlyTimelockAdmin nonReentrant {
         bytes32 actionKey = _setPriceFeedActionKey(
             token,
             priceFeed,
             priceFeedMultiplier,
+            priceFeedHeartbeatDuration,
             stablePrice
         );
 
@@ -232,15 +237,17 @@ contract Timelock is ReentrancyGuard, RoleModule, BasicMulticall {
 
         dataStore.setAddress(Keys.priceFeedKey(token), priceFeed);
         dataStore.setUint(Keys.priceFeedMultiplierKey(token), priceFeedMultiplier);
+        dataStore.setUint(Keys.priceFeedHeartbeatDurationKey(token), priceFeedHeartbeatDuration);
         dataStore.setUint(Keys.stablePriceKey(token), stablePrice);
 
         EventUtils.EventLogData memory eventData;
         eventData.addressItems.initItems(2);
         eventData.addressItems.setItem(0, "token", token);
         eventData.addressItems.setItem(1, "priceFeed", priceFeed);
-        eventData.uintItems.initItems(2);
+        eventData.uintItems.initItems(3);
         eventData.uintItems.setItem(0, "priceFeedMultiplier", priceFeedMultiplier);
-        eventData.uintItems.setItem(1, "stablePrice", stablePrice);
+        eventData.uintItems.setItem(1, "priceFeedHeartbeatDuration", priceFeedHeartbeatDuration);
+        eventData.uintItems.setItem(2, "stablePrice", stablePrice);
         eventEmitter.emitEventLog1(
             "SetPriceFeed",
             actionKey,
@@ -299,6 +306,7 @@ contract Timelock is ReentrancyGuard, RoleModule, BasicMulticall {
         address token,
         address priceFeed,
         uint256 priceFeedMultiplier,
+        uint256 priceFeedHeartbeatDuration,
         uint256 stablePrice
     ) internal pure returns (bytes32) {
         return keccak256(abi.encodePacked(
@@ -306,6 +314,7 @@ contract Timelock is ReentrancyGuard, RoleModule, BasicMulticall {
             token,
             priceFeed,
             priceFeedMultiplier,
+            priceFeedHeartbeatDuration,
             stablePrice
         ));
     }

--- a/contracts/data/Keys.sol
+++ b/contracts/data/Keys.sol
@@ -194,6 +194,8 @@ library Keys {
     bytes32 public constant PRICE_FEED = keccak256(abi.encode("PRICE_FEED"));
     // @dev key for price feed multiplier
     bytes32 public constant PRICE_FEED_MULTIPLIER = keccak256(abi.encode("PRICE_FEED_MULTIPLIER"));
+    // @dev key for price feed heartbeat
+    bytes32 public constant PRICE_FEED_HEARTBEAT_DURATION = keccak256(abi.encode("PRICE_FEED_HEARTBEAT_DURATION"));
     // @dev key for stable price
     bytes32 public constant STABLE_PRICE = keccak256(abi.encode("STABLE_PRICE"));
     // @dev key for reserve factor
@@ -1000,6 +1002,13 @@ library Keys {
     function priceFeedMultiplierKey(address token) internal pure returns (bytes32) {
         return keccak256(abi.encode(
             PRICE_FEED_MULTIPLIER,
+            token
+        ));
+    }
+
+    function priceFeedHeartbeatDurationKey(address token) internal pure returns (bytes32) {
+        return keccak256(abi.encode(
+            PRICE_FEED_HEARTBEAT_DURATION,
             token
         ));
     }

--- a/contracts/errors/Errors.sol
+++ b/contracts/errors/Errors.sol
@@ -93,6 +93,7 @@ library Errors {
     error MaxPricesNotSorted(address token, uint256 price, uint256 prevPrice);
     error EmptyPriceFeedMultiplier(address token);
     error InvalidFeedPrice(address token, int256 price);
+    error PriceFeedNotUpdated(address token, uint256 timestamp, uint256 heartbeatDuration);
     error MaxSignerIndex(uint256 signerIndex, uint256 maxSignerIndex);
     error DuplicateSigner(uint256 signerIndex);
     error InvalidOraclePrice(address token);

--- a/contracts/errors/Errors.sol
+++ b/contracts/errors/Errors.sol
@@ -92,7 +92,7 @@ library Errors {
     error MinPricesNotSorted(address token, uint256 price, uint256 prevPrice);
     error MaxPricesNotSorted(address token, uint256 price, uint256 prevPrice);
     error EmptyPriceFeedMultiplier(address token);
-    error EmptyFeedPrice(address token);
+    error InvalidFeedPrice(address token, int256 price);
     error MaxSignerIndex(uint256 signerIndex, uint256 maxSignerIndex);
     error DuplicateSigner(uint256 signerIndex);
     error InvalidOraclePrice(address token);

--- a/contracts/mock/MockPriceFeed.sol
+++ b/contracts/mock/MockPriceFeed.sol
@@ -32,7 +32,7 @@ contract MockPriceFeed is IPriceFeed {
             uint80(0), // roundId
             answer, // answer
             0, // startedAt
-            0, // updatedAt
+            block.timestamp - 60, // updatedAt
             uint80(0) // answeredInRound
         );
     }

--- a/contracts/oracle/Oracle.sol
+++ b/contracts/oracle/Oracle.sol
@@ -568,14 +568,14 @@ contract Oracle is RoleModule {
                 /* uint80 answeredInRound */
             ) = priceFeed.latestRoundData();
 
+            if (_price <= 0) {
+                revert Errors.InvalidFeedPrice(token, _price);
+            }
+
             uint256 price = SafeCast.toUint256(_price);
             uint256 precision = getPriceFeedMultiplier(dataStore, token);
 
             price = price * precision / Precision.FLOAT_PRECISION;
-
-            if (price == 0) {
-                revert Errors.EmptyFeedPrice(token);
-            }
 
             uint256 stablePrice = getStablePrice(dataStore, token);
 

--- a/contracts/oracle/Oracle.sol
+++ b/contracts/oracle/Oracle.sol
@@ -564,12 +564,17 @@ contract Oracle is RoleModule {
                 /* uint80 roundID */,
                 int256 _price,
                 /* uint256 startedAt */,
-                /* uint256 timestamp */,
+                uint256 timestamp,
                 /* uint80 answeredInRound */
             ) = priceFeed.latestRoundData();
 
             if (_price <= 0) {
                 revert Errors.InvalidFeedPrice(token, _price);
+            }
+
+            uint256 heartbeatDuration = dataStore.getUint(Keys.priceFeedHeartbeatDurationKey(token));
+            if (block.timestamp > timestamp && block.timestamp - timestamp > heartbeatDuration) {
+                revert Errors.PriceFeedNotUpdated(token, timestamp, heartbeatDuration);
             }
 
             uint256 price = SafeCast.toUint256(_price);

--- a/deploy/configureOracleTokens.ts
+++ b/deploy/configureOracleTokens.ts
@@ -31,6 +31,12 @@ const func = async ({ gmx, deployments }: HardhatRuntimeEnvironment) => {
       const priceFeedMultiplierKey = keys.priceFeedMultiplierKey(token.address);
       const priceFeedMultiplier = expandDecimals(1, 60 - priceFeed.decimals - token.decimals);
       await setUintIfDifferent(priceFeedMultiplierKey, priceFeedMultiplier, `${tokenSymbol} price feed multiplier`);
+
+      await setUintIfDifferent(
+        keys.priceFeedHeartbeatDurationKey(token.address),
+        priceFeed.heartbeatDuration,
+        `${tokenSymbol} heartbeat duration`
+      );
     }
   }
 };

--- a/test/config/Timelock.ts
+++ b/test/config/Timelock.ts
@@ -70,12 +70,17 @@ describe("Timelock", () => {
     expect(await dataStore.getUint(keys.priceFeedMultiplierKey(wnt.address))).eq(0);
     expect(await dataStore.getUint(keys.stablePriceKey(wnt.address))).eq(0);
 
-    await timelock.connect(user0).signalSetPriceFeed(wnt.address, user2.address, 1000, decimalToFloat(5000));
+    await timelock
+      .connect(user0)
+      .signalSetPriceFeed(wnt.address, user2.address, 1000, 24 * 60 * 60, decimalToFloat(5000));
     await time.increase(1 * 24 * 60 * 60 + 10);
-    await timelock.connect(user0).setPriceFeedAfterSignal(wnt.address, user2.address, 1000, decimalToFloat(5000));
+    await timelock
+      .connect(user0)
+      .setPriceFeedAfterSignal(wnt.address, user2.address, 1000, 24 * 60 * 60, decimalToFloat(5000));
 
     expect(await dataStore.getAddress(keys.priceFeedKey(wnt.address))).eq(user2.address);
     expect(await dataStore.getUint(keys.priceFeedMultiplierKey(wnt.address))).eq(1000);
+    expect(await dataStore.getUint(keys.priceFeedHeartbeatDurationKey(wnt.address))).eq(24 * 60 * 60);
     expect(await dataStore.getUint(keys.stablePriceKey(wnt.address))).eq(decimalToFloat(5000));
   });
 });

--- a/test/oracle/Oracle.ts
+++ b/test/oracle/Oracle.ts
@@ -34,7 +34,6 @@ describe("Oracle", () => {
 
   it("inits", async () => {
     expect(await oracle.oracleStore()).to.eq(oracleStore.address);
-    expect(await oracle.SALT()).to.eq(oracleSalt);
   });
 
   it("setPrices", async () => {

--- a/utils/keys.ts
+++ b/utils/keys.ts
@@ -55,6 +55,7 @@ export const REQUEST_EXPIRATION_BLOCK_AGE = hashString("REQUEST_EXPIRATION_BLOCK
 
 export const PRICE_FEED = hashString("PRICE_FEED");
 export const PRICE_FEED_MULTIPLIER = hashString("PRICE_FEED_MULTIPLIER");
+export const PRICE_FEED_HEARTBEAT_DURATION = hashString("PRICE_FEED_HEARTBEAT_DURATION");
 export const STABLE_PRICE = hashString("STABLE_PRICE");
 
 export const ORACLE_TYPE = hashString("ORACLE_TYPE");
@@ -191,6 +192,10 @@ export function priceFeedKey(token: string) {
 
 export function priceFeedMultiplierKey(token: string) {
   return hashData(["bytes32", "address"], [PRICE_FEED_MULTIPLIER, token]);
+}
+
+export function priceFeedHeartbeatDurationKey(token: string) {
+  return hashData(["bytes32", "address"], [PRICE_FEED_HEARTBEAT_DURATION, token]);
 }
 
 export function stablePriceKey(token: string) {


### PR DESCRIPTION
- Throw a custom error for zero / negative feed prices
- Add a heartbeat duration to prevent stale prices from being used
- Calculate the chainid within the transaction to reduce issues that may occur due to chain forks