### PR TITLE
Update rounding of funding fees

### DIFF
--- a/contracts/position/DecreasePositionUtils.sol
+++ b/contracts/position/DecreasePositionUtils.sol
@@ -210,12 +210,8 @@ library DecreasePositionUtils {
 
             PositionStoreUtils.remove(params.contracts.dataStore, params.positionKey, params.order.account());
         } else {
-            if (!fees.funding.hasPendingLongTokenFundingFee) {
-                params.position.setLongTokenFundingAmountPerSize(fees.funding.latestLongTokenFundingAmountPerSize);
-            }
-            if (!fees.funding.hasPendingShortTokenFundingFee) {
-                params.position.setShortTokenFundingAmountPerSize(fees.funding.latestShortTokenFundingAmountPerSize);
-            }
+            params.position.setLongTokenFundingAmountPerSize(fees.funding.latestLongTokenFundingAmountPerSize);
+            params.position.setShortTokenFundingAmountPerSize(fees.funding.latestShortTokenFundingAmountPerSize);
             params.position.setBorrowingFactor(cache.nextPositionBorrowingFactor);
 
             PositionUtils.validatePosition(

--- a/contracts/position/IncreasePositionUtils.sol
+++ b/contracts/position/IncreasePositionUtils.sol
@@ -125,12 +125,8 @@ library IncreasePositionUtils {
 
         params.position.setSizeInUsd(cache.nextPositionSizeInUsd);
         params.position.setSizeInTokens(params.position.sizeInTokens() + cache.sizeDeltaInTokens);
-        if (!fees.funding.hasPendingLongTokenFundingFee) {
-            params.position.setLongTokenFundingAmountPerSize(fees.funding.latestLongTokenFundingAmountPerSize);
-        }
-        if (!fees.funding.hasPendingShortTokenFundingFee) {
-            params.position.setShortTokenFundingAmountPerSize(fees.funding.latestShortTokenFundingAmountPerSize);
-        }
+        params.position.setLongTokenFundingAmountPerSize(fees.funding.latestLongTokenFundingAmountPerSize);
+        params.position.setShortTokenFundingAmountPerSize(fees.funding.latestShortTokenFundingAmountPerSize);
 
         PositionUtils.incrementClaimableFundingAmount(params, fees);
 

--- a/contracts/position/PositionEventUtils.sol
+++ b/contracts/position/PositionEventUtils.sol
@@ -264,10 +264,8 @@ library PositionEventUtils {
         eventData.intItems.setItem(0, "latestLongTokenFundingAmountPerSize", fees.funding.latestLongTokenFundingAmountPerSize);
         eventData.intItems.setItem(1, "latestShortTokenFundingAmountPerSize", fees.funding.latestShortTokenFundingAmountPerSize);
 
-        eventData.boolItems.initItems(3);
-        eventData.boolItems.setItem(0, "hasPendingLongTokenFundingFee", fees.funding.hasPendingLongTokenFundingFee);
-        eventData.boolItems.setItem(1, "hasPendingShortTokenFundingFee", fees.funding.hasPendingShortTokenFundingFee);
-        eventData.boolItems.setItem(2, "isIncrease", isIncrease);
+        eventData.boolItems.initItems(1);
+        eventData.boolItems.setItem(0, "isIncrease", isIncrease);
 
         eventEmitter.emitEventLog1(
             eventName,

--- a/contracts/pricing/PositionPricingUtils.sol
+++ b/contracts/pricing/PositionPricingUtils.sol
@@ -109,16 +109,12 @@ library PositionPricingUtils {
     // amount per size for the market
     // @param latestShortTokenFundingAmountPerSize the latest short token funding
     // amount per size for the market
-    // @param hasPendingLongTokenFundingFee whether there is a pending long token funding fee
-    // @param hasPendingShortTokenFundingFee whether there is a pending short token funding fee
     struct PositionFundingFees {
         uint256 fundingFeeAmount;
         uint256 claimableLongTokenAmount;
         uint256 claimableShortTokenAmount;
         int256 latestLongTokenFundingAmountPerSize;
         int256 latestShortTokenFundingAmountPerSize;
-        bool hasPendingLongTokenFundingFee;
-        bool hasPendingShortTokenFundingFee;
     }
 
     // @dev GetPositionFeesAfterReferralCache struct used in getPositionFees
@@ -429,16 +425,13 @@ library PositionPricingUtils {
         fundingFees.latestLongTokenFundingAmountPerSize = latestLongTokenFundingAmountPerSize;
         fundingFees.latestShortTokenFundingAmountPerSize = latestShortTokenFundingAmountPerSize;
 
-        int256 longTokenFundingFeeAmount;
-        int256 shortTokenFundingFeeAmount;
-
-        (fundingFees.hasPendingLongTokenFundingFee, longTokenFundingFeeAmount) = MarketUtils.getFundingFeeAmount(
+        int256 longTokenFundingFeeAmount = MarketUtils.getFundingFeeAmount(
             fundingFees.latestLongTokenFundingAmountPerSize,
             position.longTokenFundingAmountPerSize(),
             position.sizeInUsd()
         );
 
-        (fundingFees.hasPendingShortTokenFundingFee, shortTokenFundingFeeAmount) = MarketUtils.getFundingFeeAmount(
+        int256 shortTokenFundingFeeAmount = MarketUtils.getFundingFeeAmount(
             fundingFees.latestShortTokenFundingAmountPerSize,
             position.shortTokenFundingAmountPerSize(),
             position.sizeInUsd()

--- a/test/exchange/PositionFees.ts
+++ b/test/exchange/PositionFees.ts
@@ -204,8 +204,6 @@ describe("Exchange.PositionFees", () => {
             "10000000000000000000"
           );
           expect(positionFeesCollectedEvent.latestShortTokenFundingAmountPerSize).eq("0");
-          expect(positionFeesCollectedEvent.hasPendingLongTokenFundingFee).eq(false);
-          expect(positionFeesCollectedEvent.hasPendingShortTokenFundingFee).eq(false);
           expect(positionFeesCollectedEvent.isIncrease).eq(false);
         },
       },
@@ -286,8 +284,6 @@ describe("Exchange.PositionFees", () => {
             "240000000000",
             "100000000000"
           );
-          expect(positionFeesCollectedEvent.hasPendingLongTokenFundingFee).eq(false);
-          expect(positionFeesCollectedEvent.hasPendingShortTokenFundingFee).eq(false);
           expect(positionFeesCollectedEvent.isIncrease).eq(false);
         },
       },


### PR DESCRIPTION
Previously getFundingFeeAmount returned a hasPendingFundingFee value in case the funding fee amount is lower than one unit of token, as reported in a Sherlock audit issue, this logic can still result in less funding fees being paid as there may be pending funding fees that are more than one unit of token but have some decimal value that would not be accounted for due to rounding.

This change updates the logic to always round funding fee amounts up.