### PR TITLE
Remove threshold virtual price impact

### DIFF
--- a/contracts/config/Config.sol
+++ b/contracts/config/Config.sol
@@ -232,8 +232,6 @@ contract Config is ReentrancyGuard, RoleModule, BasicMulticall {
         allowedBaseKeys[Keys.VIRTUAL_MARKET_ID] = true;
         allowedBaseKeys[Keys.VIRTUAL_INVENTORY_FOR_SWAPS] = true;
         allowedBaseKeys[Keys.VIRTUAL_INVENTORY_FOR_POSITIONS] = true;
-        allowedBaseKeys[Keys.THRESHOLD_POSITION_IMPACT_FACTOR_FOR_VIRTUAL_INVENTORY] = true;
-        allowedBaseKeys[Keys.THRESHOLD_SWAP_IMPACT_FACTOR_FOR_VIRTUAL_INVENTORY] = true;
 
         allowedBaseKeys[Keys.POSITION_IMPACT_FACTOR] = true;
         allowedBaseKeys[Keys.POSITION_IMPACT_EXPONENT_FACTOR] = true;

--- a/contracts/data/Keys.sol
+++ b/contracts/data/Keys.sol
@@ -149,10 +149,6 @@ library Keys {
     bytes32 public constant VIRTUAL_INVENTORY_FOR_SWAPS = keccak256(abi.encode("VIRTUAL_INVENTORY_FOR_SWAPS"));
     // @dev key for the virtual inventory for positions
     bytes32 public constant VIRTUAL_INVENTORY_FOR_POSITIONS = keccak256(abi.encode("VIRTUAL_INVENTORY_FOR_POSITIONS"));
-    // @dev key for the threshold position impact for virtual inventory
-    bytes32 public constant THRESHOLD_POSITION_IMPACT_FACTOR_FOR_VIRTUAL_INVENTORY = keccak256(abi.encode("THRESHOLD_POSITION_IMPACT_FACTOR_FOR_VIRTUAL_INVENTORY"));
-    // @dev key for the threshold swap impact for virtual inventory
-    bytes32 public constant THRESHOLD_SWAP_IMPACT_FACTOR_FOR_VIRTUAL_INVENTORY = keccak256(abi.encode("THRESHOLD_SWAP_IMPACT_FACTOR_FOR_VIRTUAL_INVENTORY"));
 
     // @dev key for the position impact factor
     bytes32 public constant POSITION_IMPACT_FACTOR = keccak256(abi.encode("POSITION_IMPACT_FACTOR"));
@@ -511,24 +507,6 @@ library Keys {
            VIRTUAL_INVENTORY_FOR_SWAPS,
            virtualMarketId,
            token
-       ));
-   }
-
-   // @dev the key for the threshold position impact for virtual inventory
-   // @param virtualTokenId the virtual token id to check
-   function thresholdPositionImpactFactorForVirtualInventoryKey(bytes32 virtualTokenId) internal pure returns (bytes32) {
-       return keccak256(abi.encode(
-           THRESHOLD_POSITION_IMPACT_FACTOR_FOR_VIRTUAL_INVENTORY,
-           virtualTokenId
-       ));
-   }
-
-   // @dev the key for the threshold swap impact for virtual inventory
-   // @param virtualMarketId the virtual market id to check
-   function thresholdSwapImpactFactorForVirtualInventoryKey(bytes32 virtualMarketId) internal pure returns (bytes32) {
-       return keccak256(abi.encode(
-           THRESHOLD_SWAP_IMPACT_FACTOR_FOR_VIRTUAL_INVENTORY,
-           virtualMarketId
        ));
    }
 

--- a/contracts/market/MarketUtils.sol
+++ b/contracts/market/MarketUtils.sol
@@ -1372,30 +1372,6 @@ library MarketUtils {
         return (true, dataStore.getInt(Keys.virtualInventoryForPositionsKey(tokenId)));
     }
 
-    // @dev get the threshold position impact for virtual inventory
-    // @param dataStore DataStore
-    // @param token the token to check
-    function getThresholdPositionImpactFactorForVirtualInventory(DataStore dataStore, address token) internal view returns (bool, int256) {
-        bytes32 tokenId = dataStore.getBytes32(Keys.virtualTokenIdKey(token));
-        if (tokenId == bytes32(0)) {
-            return (false, 0);
-        }
-
-        return (true, dataStore.getInt(Keys.thresholdPositionImpactFactorForVirtualInventoryKey(tokenId)));
-    }
-
-    // @dev get the threshold swap impact for virtual inventory
-    // @param dataStore DataStore
-    // @param token the token to check
-    function getThresholdSwapImpactFactorForVirtualInventory(DataStore dataStore, address market) internal view returns (bool, int256) {
-        bytes32 marketId = dataStore.getBytes32(Keys.virtualMarketIdKey(market));
-        if (marketId == bytes32(0)) {
-            return (false, 0);
-        }
-
-        return (true, dataStore.getInt(Keys.thresholdSwapImpactFactorForVirtualInventoryKey(marketId)));
-    }
-
     // @dev update the virtual inventory for swaps
     // @param dataStore DataStore
     // @param market the market to update


### PR DESCRIPTION
It was previously possible to specify a threshold virtual price impact, below which, virtual price impact would not apply, this was meant to keep price impact low. However, as reported in a Sherlock audit issue, this logic may reduce the effectiveness in preventing price manipulation which is the purpose of having virtual price impact.