### PR TITLE
Add market type

### DIFF
--- a/contracts/error/Errors.sol
+++ b/contracts/error/Errors.sol
@@ -58,6 +58,9 @@ library Errors {
     error InsufficientExecutionFee(uint256 minExecutionFee, uint256 executionFee);
     error InsufficientWntAmountForExecutionFee(uint256 wntAmount, uint256 executionFee);
 
+    // MarketFactory errors
+    error MarketAlreadyExists(bytes32 salt, address existingMarketAddress);
+
     // MarketUtils errors
     error EmptyMarket();
     error DisabledMarket(address market);

--- a/contracts/market/MarketStoreUtils.sol
+++ b/contracts/market/MarketStoreUtils.sol
@@ -14,12 +14,13 @@ import "./Market.sol";
 library MarketStoreUtils {
     using Market for Market.Props;
 
+    bytes32 public constant MARKET_KEY = keccak256(abi.encode("MARKET_KEY"));
     bytes32 public constant MARKET_TOKEN = keccak256(abi.encode("MARKET_TOKEN"));
     bytes32 public constant INDEX_TOKEN = keccak256(abi.encode("INDEX_TOKEN"));
     bytes32 public constant LONG_TOKEN = keccak256(abi.encode("LONG_TOKEN"));
     bytes32 public constant SHORT_TOKEN = keccak256(abi.encode("SHORT_TOKEN"));
 
-    function get(DataStore dataStore, address key) external view returns (Market.Props memory) {
+    function get(DataStore dataStore, address key) public view returns (Market.Props memory) {
         Market.Props memory market;
         if (!dataStore.containsAddress(Keys.MARKET_LIST, key)) {
             return market;
@@ -44,9 +45,22 @@ library MarketStoreUtils {
         return market;
     }
 
-    function set(DataStore dataStore, address key, Market.Props memory market) external {
+    function getBySalt(DataStore dataStore, bytes32 salt) external view returns (Market.Props memory) {
+        address key = dataStore.getAddress(salt);
+        return get(dataStore, key);
+    }
+
+    function set(DataStore dataStore, address key, bytes32 salt, Market.Props memory market) external {
         dataStore.addAddress(
             Keys.MARKET_LIST,
+            key
+        );
+
+        // the salt is based on the market props while the key gives the market's address
+        // use the salt to store a reference to the key to allow the key to be retrieved
+        // using just the salt value
+        dataStore.setAddress(
+            salt,
             key
         );
 

--- a/contracts/reader/Reader.sol
+++ b/contracts/reader/Reader.sol
@@ -41,6 +41,10 @@ contract Reader {
         return MarketStoreUtils.get(dataStore, key);
     }
 
+    function getMarketBySalt(DataStore dataStore, bytes32 salt) external view returns (Market.Props memory) {
+        return MarketStoreUtils.getBySalt(dataStore, salt);
+    }
+
     function getDeposit(DataStore dataStore, bytes32 key) external view returns (Deposit.Props memory) {
         return DepositStoreUtils.get(dataStore, key);
     }

--- a/contracts/test/MarketStoreUtilsTest.sol
+++ b/contracts/test/MarketStoreUtilsTest.sol
@@ -15,8 +15,8 @@ contract MarketStoreUtilsTest {
         return market;
     }
 
-    function setMarket(DataStore dataStore, address key, Market.Props memory market) external {
-        MarketStoreUtils.set(dataStore, key, market);
+    function setMarket(DataStore dataStore, address key, bytes32 salt, Market.Props memory market) external {
+        MarketStoreUtils.set(dataStore, key, salt, market);
     }
 
     function removeMarket(DataStore dataStore, address key) external {

--- a/deploy/deployAndConfigureMarkets.ts
+++ b/deploy/deployAndConfigureMarkets.ts
@@ -1,6 +1,8 @@
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import * as keys from "../utils/keys";
 import { setBytes32IfDifferent, setUintIfDifferent } from "../utils/dataStore";
+import { hashString } from "../utils/hash";
+import { DEFAULT_MARKET_TYPE } from "../utils/market";
 import { ethers } from "ethers";
 
 function getMarketTokenAddresses(marketConfig, tokens) {
@@ -49,8 +51,17 @@ const func = async ({ deployments, getNamedAccounts, gmx }: HardhatRuntimeEnviro
       continue;
     }
 
-    log("creating market %s:%s:%s", indexToken, longToken, shortToken);
-    await execute("MarketFactory", { from: deployer, log: true }, "createMarket", indexToken, longToken, shortToken);
+    const marketType = DEFAULT_MARKET_TYPE;
+    log("creating market %s:%s:%s:%s", indexToken, longToken, shortToken, marketType);
+    await execute(
+      "MarketFactory",
+      { from: deployer, log: true },
+      "createMarket",
+      indexToken,
+      longToken,
+      shortToken,
+      marketType
+    );
   }
 
   async function setReserveFactor(marketToken: string, isLong: boolean, reserveFactor: number) {

--- a/scripts/createDepositSynthetic.ts
+++ b/scripts/createDepositSynthetic.ts
@@ -1,6 +1,6 @@
 import hre from "hardhat";
 
-import { getMarketTokenAddress } from "../utils/market";
+import { getMarketTokenAddress, DEFAULT_MARKET_TYPE } from "../utils/market";
 import { bigNumberify, expandDecimals } from "../utils/math";
 
 import { WNT, ExchangeRouter, MintableToken } from "../typechain-types";
@@ -81,6 +81,7 @@ async function main() {
     syntheticToken.address,
     weth.address,
     usdc.address,
+    DEFAULT_MARKET_TYPE,
     marketFactory.address,
     roleStore.address,
     dataStore.address

--- a/scripts/createDepositWethUsdc.ts
+++ b/scripts/createDepositWethUsdc.ts
@@ -1,6 +1,6 @@
 import hre from "hardhat";
 
-import { getMarketTokenAddress } from "../utils/market";
+import { getMarketTokenAddress, DEFAULT_MARKET_TYPE } from "../utils/market";
 import { bigNumberify, expandDecimals } from "../utils/math";
 
 import { WNT, ExchangeRouter, MintableToken } from "../typechain-types";
@@ -88,6 +88,7 @@ async function main() {
     weth.address,
     weth.address,
     usdc.address,
+    DEFAULT_MARKET_TYPE,
     marketFactory.address,
     roleStore.address,
     dataStore.address

--- a/scripts/createDepositWnt.ts
+++ b/scripts/createDepositWnt.ts
@@ -1,6 +1,6 @@
 import hre from "hardhat";
 
-import { getMarketTokenAddress } from "../utils/market";
+import { getMarketTokenAddress, DEFAULT_MARKET_TYPE } from "../utils/market";
 import { bigNumberify, expandDecimals } from "../utils/math";
 
 import { WNT, ExchangeRouter, MintableToken } from "../typechain-types";
@@ -67,6 +67,7 @@ async function main() {
     wnt.address,
     wnt.address,
     usdc.address,
+    DEFAULT_MARKET_TYPE,
     marketFactory.address,
     roleStore.address,
     dataStore.address

--- a/scripts/createLimitLongWethUsdc.ts
+++ b/scripts/createLimitLongWethUsdc.ts
@@ -1,6 +1,6 @@
 import hre from "hardhat";
 
-import { getMarketTokenAddress } from "../utils/market";
+import { getMarketTokenAddress, DEFAULT_MARKET_TYPE } from "../utils/market";
 import { bigNumberify, expandDecimals } from "../utils/math";
 import { WNT, ExchangeRouter, MintableToken } from "../typechain-types";
 import { BaseOrderUtils } from "../typechain-types/contracts/router/ExchangeRouter";
@@ -71,6 +71,7 @@ async function main() {
     weth.address,
     weth.address,
     usdc.address,
+    DEFAULT_MARKET_TYPE,
     marketFactory.address,
     roleStore.address,
     dataStore.address

--- a/scripts/createMarketDecreaseLongWethUsdc.ts
+++ b/scripts/createMarketDecreaseLongWethUsdc.ts
@@ -1,6 +1,6 @@
 import hre from "hardhat";
 
-import { getMarketTokenAddress } from "../utils/market";
+import { getMarketTokenAddress, DEFAULT_MARKET_TYPE } from "../utils/market";
 import { bigNumberify, expandDecimals } from "../utils/math";
 import { WNT, ExchangeRouter, MintableToken } from "../typechain-types";
 import { BaseOrderUtils } from "../typechain-types/contracts/router/ExchangeRouter";
@@ -56,6 +56,7 @@ async function main() {
     weth.address,
     weth.address,
     usdc.address,
+    DEFAULT_MARKET_TYPE,
     marketFactory.address,
     roleStore.address,
     dataStore.address

--- a/scripts/createMarketIncreaseLongWethUsdc.ts
+++ b/scripts/createMarketIncreaseLongWethUsdc.ts
@@ -1,6 +1,6 @@
 import hre from "hardhat";
 
-import { getMarketTokenAddress } from "../utils/market";
+import { getMarketTokenAddress, DEFAULT_MARKET_TYPE } from "../utils/market";
 import { bigNumberify, expandDecimals } from "../utils/math";
 import { WNT, ExchangeRouter, MintableToken } from "../typechain-types";
 import { BaseOrderUtils } from "../typechain-types/contracts/router/ExchangeRouter";
@@ -71,6 +71,7 @@ async function main() {
     weth.address,
     weth.address,
     usdc.address,
+    DEFAULT_MARKET_TYPE,
     marketFactory.address,
     roleStore.address,
     dataStore.address

--- a/scripts/createMarketSwapWethUsdc.ts
+++ b/scripts/createMarketSwapWethUsdc.ts
@@ -1,6 +1,6 @@
 import hre from "hardhat";
 
-import { getMarketTokenAddress } from "../utils/market";
+import { getMarketTokenAddress, DEFAULT_MARKET_TYPE } from "../utils/market";
 import { bigNumberify, expandDecimals } from "../utils/math";
 import { WNT, ExchangeRouter, MintableToken } from "../typechain-types";
 import { BaseOrderUtils } from "../typechain-types/contracts/router/ExchangeRouter";
@@ -70,6 +70,7 @@ async function main() {
     weth.address,
     weth.address,
     usdc.address,
+    DEFAULT_MARKET_TYPE,
     marketFactory.address,
     roleStore.address,
     dataStore.address

--- a/scripts/printPoolData.ts
+++ b/scripts/printPoolData.ts
@@ -2,7 +2,7 @@ import hre from "hardhat";
 
 import * as keys from "../utils/keys";
 
-import { getMarketTokenAddress } from "../utils/market";
+import { getMarketTokenAddress, DEFAULT_MARKET_TYPE } from "../utils/market";
 
 import { MintableToken } from "../typechain-types";
 
@@ -19,6 +19,7 @@ async function main() {
     weth.address,
     weth.address,
     usdc.address,
+    DEFAULT_MARKET_TYPE,
     marketFactory.address,
     roleStore.address,
     dataStore.address

--- a/test/market/MarketStoreUtils.ts
+++ b/test/market/MarketStoreUtils.ts
@@ -3,7 +3,7 @@ import { deployContract } from "../../utils/deploy";
 import { deployFixture } from "../../utils/fixture";
 
 import { grantRole } from "../../utils/role";
-import { getMarketCount, getMarketKeys } from "../../utils/market";
+import { getMarketCount, getMarketKeys, DEFAULT_MARKET_TYPE } from "../../utils/market";
 import { logGasUsage } from "../../utils/gas";
 
 describe("MarketStoreUtils", () => {
@@ -28,6 +28,7 @@ describe("MarketStoreUtils", () => {
   it("get, set, remove", async () => {
     const sampleItem = {};
     const itemKey = accountList[accountList.length - 1].address;
+    const marketType = DEFAULT_MARKET_TYPE;
 
     const getEmptyItem = marketStoreUtilsTest.getEmptyMarket;
     const getItem = async (dataStore, key) => {
@@ -36,7 +37,7 @@ describe("MarketStoreUtils", () => {
     const getItemCount = getMarketCount;
     const getItemKeys = getMarketKeys;
     const setItem = async (dataStore, key, sampleItem) => {
-      return await marketStoreUtilsTest.setMarket(dataStore.address, key, sampleItem);
+      return await marketStoreUtilsTest.setMarket(dataStore.address, key, marketType, sampleItem);
     };
     const removeItem = async (dataStore, itemKey) => {
       return await marketStoreUtilsTest.removeMarket(dataStore.address, itemKey);

--- a/utils/fixture.ts
+++ b/utils/fixture.ts
@@ -2,7 +2,7 @@ import hre from "hardhat";
 
 import { expandDecimals } from "./math";
 import { hashData } from "./hash";
-import { getMarketTokenAddress } from "./market";
+import { getMarketTokenAddress, DEFAULT_MARKET_TYPE } from "./market";
 import { getSyntheticTokenAddress } from "./token";
 
 export async function deployFixture() {
@@ -83,6 +83,7 @@ export async function deployFixture() {
     wnt.address,
     wnt.address,
     usdc.address,
+    DEFAULT_MARKET_TYPE,
     marketFactory.address,
     roleStore.address,
     dataStore.address
@@ -93,6 +94,7 @@ export async function deployFixture() {
     ethers.constants.AddressZero,
     wnt.address,
     usdc.address,
+    DEFAULT_MARKET_TYPE,
     marketFactory.address,
     roleStore.address,
     dataStore.address
@@ -103,6 +105,7 @@ export async function deployFixture() {
     wbtc.address,
     wbtc.address,
     usdc.address,
+    DEFAULT_MARKET_TYPE,
     marketFactory.address,
     roleStore.address,
     dataStore.address
@@ -113,6 +116,7 @@ export async function deployFixture() {
     getSyntheticTokenAddress("SOL"),
     wnt.address,
     usdc.address,
+    DEFAULT_MARKET_TYPE,
     marketFactory.address,
     roleStore.address,
     dataStore.address

--- a/utils/market.ts
+++ b/utils/market.ts
@@ -1,10 +1,12 @@
 import { calculateCreate2 } from "eth-create2-calculator";
 import { expandDecimals } from "./math";
-import { hashData } from "./hash";
+import { hashData, hashString } from "./hash";
 import { poolAmountKey, swapImpactPoolAmountKey } from "./keys";
 import * as keys from "./keys";
 
 import MarketTokenArtifact from "../artifacts/contracts/market/MarketToken.sol/MarketToken.json";
+
+export const DEFAULT_MARKET_TYPE = hashString("basic-v1");
 
 export function getMarketCount(dataStore) {
   return dataStore.getAddressCount(keys.MARKET_LIST);
@@ -63,11 +65,15 @@ export function getMarketTokenAddress(
   indexToken,
   longToken,
   shortToken,
+  marketType,
   marketFactoryAddress,
   roleStoreAddress,
   dataStoreAddress
 ) {
-  const salt = hashData(["string", "address", "address", "address"], ["GMX_MARKET", indexToken, longToken, shortToken]);
+  const salt = hashData(
+    ["string", "address", "address", "address", "bytes32"],
+    ["GMX_MARKET", indexToken, longToken, shortToken, marketType]
+  );
   const byteCode = MarketTokenArtifact.bytecode;
   return calculateCreate2(marketFactoryAddress, salt, byteCode, {
     params: [roleStoreAddress, dataStoreAddress],


### PR DESCRIPTION
This allows multiple markets with the same index token, long token and short token to be more easily created.