### PR TITLE
Store market salts

### DIFF
--- a/contracts/market/MarketFactory.sol
+++ b/contracts/market/MarketFactory.sol
@@ -45,7 +45,7 @@ contract MarketFactory is RoleModule {
             marketType
         ));
 
-        address existingMarketAddress = dataStore.getAddress(salt);
+        address existingMarketAddress = dataStore.getAddress(MarketStoreUtils.getMarketSaltHash(salt));
         if (existingMarketAddress != address(0)) {
             revert Errors.MarketAlreadyExists(salt, existingMarketAddress);
         }

--- a/contracts/market/MarketFactory.sol
+++ b/contracts/market/MarketFactory.sol
@@ -11,7 +11,14 @@ import "./MarketUtils.sol";
 contract MarketFactory is RoleModule {
     using Market for Market.Props;
 
-    event MarketCreated(address marketToken, address indexToken, address longToken, address shortToken);
+    event MarketCreated(
+        address marketToken,
+        bytes32 salt,
+        address indexToken,
+        address longToken,
+        address
+        shortToken
+    );
 
     DataStore public immutable dataStore;
 
@@ -56,7 +63,7 @@ contract MarketFactory is RoleModule {
 
         MarketStoreUtils.set(dataStore, address(marketToken), salt, market);
 
-        emit MarketCreated(address(marketToken), indexToken, longToken, shortToken);
+        emit MarketCreated(address(marketToken), salt, indexToken, longToken, shortToken);
 
         return market;
     }

--- a/contracts/market/MarketStoreUtils.sol
+++ b/contracts/market/MarketStoreUtils.sol
@@ -47,9 +47,7 @@ library MarketStoreUtils {
     }
 
     function getBySalt(DataStore dataStore, bytes32 salt) external view returns (Market.Props memory) {
-        address key = dataStore.getAddress(
-            keccak256(abi.encode(MARKET_SALT, salt))
-        );
+        address key = dataStore.getAddress(getMarketSaltHash(salt));
         return get(dataStore, key);
     }
 
@@ -63,7 +61,7 @@ library MarketStoreUtils {
         // use the salt to store a reference to the key to allow the key to be retrieved
         // using just the salt value
         dataStore.setAddress(
-            keccak256(abi.encode(MARKET_SALT, salt)),
+            getMarketSaltHash(salt),
             key
         );
 
@@ -109,6 +107,10 @@ library MarketStoreUtils {
         dataStore.removeAddress(
             keccak256(abi.encode(key, SHORT_TOKEN))
         );
+    }
+
+    function getMarketSaltHash(bytes32 salt) internal pure returns (bytes32) {
+        return keccak256(abi.encode(MARKET_SALT, salt));
     }
 
     function getMarketCount(DataStore dataStore) internal view returns (uint256) {

--- a/contracts/market/MarketStoreUtils.sol
+++ b/contracts/market/MarketStoreUtils.sol
@@ -14,6 +14,7 @@ import "./Market.sol";
 library MarketStoreUtils {
     using Market for Market.Props;
 
+    bytes32 public constant MARKET_SALT = keccak256(abi.encode("MARKET_SALT"));
     bytes32 public constant MARKET_KEY = keccak256(abi.encode("MARKET_KEY"));
     bytes32 public constant MARKET_TOKEN = keccak256(abi.encode("MARKET_TOKEN"));
     bytes32 public constant INDEX_TOKEN = keccak256(abi.encode("INDEX_TOKEN"));
@@ -46,7 +47,9 @@ library MarketStoreUtils {
     }
 
     function getBySalt(DataStore dataStore, bytes32 salt) external view returns (Market.Props memory) {
-        address key = dataStore.getAddress(salt);
+        address key = dataStore.getAddress(
+            keccak256(abi.encode(MARKET_SALT, salt))
+        );
         return get(dataStore, key);
     }
 
@@ -60,7 +63,7 @@ library MarketStoreUtils {
         // use the salt to store a reference to the key to allow the key to be retrieved
         // using just the salt value
         dataStore.setAddress(
-            salt,
+            keccak256(abi.encode(MARKET_SALT, salt)),
             key
         );
 

--- a/contracts/oracle/Oracle.sol
+++ b/contracts/oracle/Oracle.sol
@@ -581,7 +581,7 @@ contract Oracle is RoleModule {
         }
     }
 
-    function _getPriceFeedPrice(DataStore dataStore, address token) internal returns (bool, uint256) {
+    function _getPriceFeedPrice(DataStore dataStore, address token) internal view returns (bool, uint256) {
         address priceFeedAddress = dataStore.getAddress(Keys.priceFeedKey(token));
         if (priceFeedAddress == address(0)) {
             return (false, 0);


### PR DESCRIPTION
Store market salts to prevent duplicate markets with the same market type, index token, long token and short token