### PR TITLE
Add token balance validation

### DIFF
--- a/contracts/data/Keys.sol
+++ b/contracts/data/Keys.sol
@@ -297,8 +297,17 @@ library Keys {
     // @dev key for the claimable ui fee amount
     // @param market the market for the fee
     // @param token the token for the fee
-    function claimableUiFeeAmountKey(address uiFeeReceiver, address market, address token) internal pure returns (bytes32) {
-        return keccak256(abi.encode(CLAIMABLE_UI_FEE_AMOUNT, uiFeeReceiver, market, token));
+    // @param account the account that can claim the ui fee
+    function claimableUiFeeAmountKey(address market, address token) internal pure returns (bytes32) {
+        return keccak256(abi.encode(CLAIMABLE_UI_FEE_AMOUNT, market, token));
+    }
+
+    // @dev key for the claimable ui fee amount for account
+    // @param market the market for the fee
+    // @param token the token for the fee
+    // @param account the account that can claim the ui fee
+    function claimableUiFeeAmountKey(address market, address token, address account) internal pure returns (bytes32) {
+        return keccak256(abi.encode(CLAIMABLE_UI_FEE_AMOUNT, market, token, account));
     }
 
     // @dev key for deposit gas limit
@@ -858,6 +867,19 @@ library Keys {
     // @param token the token to check
     // @param account the account to check
     // @return key for claimable funding amount
+    function claimableFundingAmountKey(address market, address token) internal pure returns (bytes32) {
+        return keccak256(abi.encode(
+            CLAIMABLE_FUNDING_AMOUNT,
+            market,
+            token
+        ));
+    }
+
+    // @dev key for claimable funding amount by account
+    // @param market the market to check
+    // @param token the token to check
+    // @param account the account to check
+    // @return key for claimable funding amount
     function claimableFundingAmountKey(address market, address token, address account) internal pure returns (bytes32) {
         return keccak256(abi.encode(
             CLAIMABLE_FUNDING_AMOUNT,
@@ -868,6 +890,20 @@ library Keys {
     }
 
     // @dev key for claimable collateral amount
+    // @param market the market to check
+    // @param token the token to check
+    // @param account the account to check
+    // @param timeKey the time key for the claimable amount
+    // @return key for claimable funding amount
+    function claimableCollateralAmountKey(address market, address token) internal pure returns (bytes32) {
+        return keccak256(abi.encode(
+            CLAIMABLE_COLLATERAL_AMOUNT,
+            market,
+            token
+        ));
+    }
+
+    // @dev key for claimable collateral amount for a timeKey for an account
     // @param market the market to check
     // @param token the token to check
     // @param account the account to check
@@ -989,6 +1025,19 @@ library Keys {
     }
 
     // @dev key for affiliate reward amount
+    // @param market the market to check
+    // @param token the token to get the key for
+    // @param account the account to get the key for
+    // @return key for affiliate reward amount
+    function affiliateRewardKey(address market, address token) internal pure returns (bytes32) {
+        return keccak256(abi.encode(
+            AFFILIATE_REWARD,
+            market,
+            token
+        ));
+    }
+
+    // @dev key for affiliate reward amount for an account
     // @param market the market to check
     // @param token the token to get the key for
     // @param account the account to get the key for

--- a/contracts/deposit/ExecuteDepositUtils.sol
+++ b/contracts/deposit/ExecuteDepositUtils.sol
@@ -152,8 +152,6 @@ library ExecuteDepositUtils {
         cache.longTokenUsd = cache.longTokenAmount * prices.longTokenPrice.midPrice();
         cache.shortTokenUsd = cache.shortTokenAmount * prices.shortTokenPrice.midPrice();
 
-        cache.receivedMarketTokens;
-
         cache.priceImpactUsd = SwapPricingUtils.getPriceImpactUsd(
             SwapPricingUtils.GetPriceImpactUsdParams(
                 params.dataStore,
@@ -206,6 +204,10 @@ library ExecuteDepositUtils {
         }
 
         DepositStoreUtils.remove(params.dataStore, params.key, deposit.account());
+
+        // validate that internal state changes are correct before calling
+        // external callbacks
+        MarketUtils.validateMarketTokenBalance(params.dataStore, market);
 
         DepositEventUtils.emitDepositExecuted(
             params.eventEmitter,
@@ -412,6 +414,8 @@ library ExecuteDepositUtils {
         if (outputToken != expectedOutputToken) {
             revert Errors.InvalidSwapOutputToken(outputToken, expectedOutputToken);
         }
+
+        MarketUtils.validateMarketTokenBalance(params.dataStore, swapPathMarkets);
 
         return outputAmount;
     }

--- a/contracts/error/Errors.sol
+++ b/contracts/error/Errors.sol
@@ -85,6 +85,7 @@ library Errors {
     error PnlFactorExceededForLongs(int256 pnlToPoolFactor, uint256 maxPnlFactor);
     error PnlFactorExceededForShorts(int256 pnlToPoolFactor, uint256 maxPnlFactor);
     error InvalidUiFeeFactor(uint256 uiFeeFactor, uint256 maxUiFeeFactor);
+    error EmptyAddressInMarketTokenBalanceValidation(address market, address token);
     error InvalidMarketTokenBalance(address market, address token, uint256 balance, uint256 expectedMinBalance);
 
     // Oracle errors

--- a/contracts/error/Errors.sol
+++ b/contracts/error/Errors.sol
@@ -85,6 +85,7 @@ library Errors {
     error PnlFactorExceededForLongs(int256 pnlToPoolFactor, uint256 maxPnlFactor);
     error PnlFactorExceededForShorts(int256 pnlToPoolFactor, uint256 maxPnlFactor);
     error InvalidUiFeeFactor(uint256 uiFeeFactor, uint256 maxUiFeeFactor);
+    error InvalidMarketTokenBalance(address market, address token, uint256 balance, uint256 expectedMinBalance);
 
     // Oracle errors
     error EmptyTokens();

--- a/contracts/fee/FeeUtils.sol
+++ b/contracts/fee/FeeUtils.sol
@@ -28,33 +28,33 @@ library FeeUtils {
     // @param eventEmitter EventEmitter
     // @param market the market to increment claimable fees for
     // @param token the fee token
-    // @param feeReceiverAmount the amount to increment
+    // @param delta the amount to increment
     // @param feeType the type of the fee
     function incrementClaimableFeeAmount(
         DataStore dataStore,
         EventEmitter eventEmitter,
         address market,
         address token,
-        uint256 feeReceiverAmount,
+        uint256 delta,
         bytes32 feeType
     ) external {
-        if (feeReceiverAmount == 0) {
+        if (delta == 0) {
             return;
         }
 
         bytes32 key = Keys.claimableFeeAmountKey(market, token);
 
-        uint256 nextClaimableFeeAmount = dataStore.incrementUint(
+        uint256 nextValue = dataStore.incrementUint(
             key,
-            feeReceiverAmount
+            delta
         );
 
         emitClaimableFeeAmountUpdated(
             eventEmitter,
             market,
             token,
-            feeReceiverAmount,
-            nextClaimableFeeAmount,
+            delta,
+            nextValue,
             feeType
         );
     }
@@ -65,18 +65,21 @@ library FeeUtils {
         address uiFeeReceiver,
         address market,
         address token,
-        uint256 feeReceiverAmount,
+        uint256 delta,
         bytes32 feeType
     ) external {
-        if (feeReceiverAmount == 0) {
+        if (delta == 0) {
             return;
         }
 
-        bytes32 key = Keys.claimableUiFeeAmountKey(uiFeeReceiver, market, token);
+        uint256 nextValue = dataStore.incrementUint(
+            Keys.claimableUiFeeAmountKey(market, token, uiFeeReceiver),
+            delta
+        );
 
-        uint256 nextClaimableFeeAmount = dataStore.incrementUint(
-            key,
-            feeReceiverAmount
+        uint256 nextPoolValue = dataStore.incrementUint(
+            Keys.claimableUiFeeAmountKey(market, token),
+            delta
         );
 
         emitClaimableUiFeeAmountUpdated(
@@ -84,8 +87,9 @@ library FeeUtils {
             uiFeeReceiver,
             market,
             token,
-            feeReceiverAmount,
-            nextClaimableFeeAmount,
+            delta,
+            nextValue,
+            nextPoolValue,
             feeType
         );
     }
@@ -134,10 +138,15 @@ library FeeUtils {
     ) internal {
         AccountUtils.validateReceiver(receiver);
 
-        bytes32 key = Keys.claimableUiFeeAmountKey(uiFeeReceiver, market, token);
+        bytes32 key = Keys.claimableUiFeeAmountKey(market, token, uiFeeReceiver);
 
         uint256 feeAmount = dataStore.getUint(key);
         dataStore.setUint(key, 0);
+
+        uint256 nextPoolValue = dataStore.decrementUint(
+            Keys.claimableUiFeeAmountKey(market, token),
+            feeAmount
+        );
 
         MarketToken(payable(market)).transferOut(
             token,
@@ -150,7 +159,8 @@ library FeeUtils {
             uiFeeReceiver,
             market,
             receiver,
-            feeAmount
+            feeAmount,
+            nextPoolValue
         );
     }
 
@@ -190,6 +200,7 @@ library FeeUtils {
         address token,
         uint256 delta,
         uint256 nextValue,
+        uint256 nextPoolValue,
         bytes32 feeType
     ) internal {
         EventUtils.EventLogData memory eventData;
@@ -199,9 +210,10 @@ library FeeUtils {
         eventData.addressItems.setItem(1, "market", market);
         eventData.addressItems.setItem(2, "token", token);
 
-        eventData.uintItems.initItems(2);
+        eventData.uintItems.initItems(3);
         eventData.uintItems.setItem(0, "delta", delta);
         eventData.uintItems.setItem(1, "nextValue", nextValue);
+        eventData.uintItems.setItem(2, "nextPoolValue", nextPoolValue);
 
         eventData.bytes32Items.initItems(1);
         eventData.bytes32Items.setItem(0, "feeType", feeType);
@@ -241,7 +253,8 @@ library FeeUtils {
         address uiFeeReceiver,
         address market,
         address receiver,
-        uint256 feeAmount
+        uint256 feeAmount,
+        uint256 nextPoolValue
     ) internal {
         EventUtils.EventLogData memory eventData;
 
@@ -250,8 +263,9 @@ library FeeUtils {
         eventData.addressItems.setItem(1, "market", market);
         eventData.addressItems.setItem(2, "receiver", receiver);
 
-        eventData.uintItems.initItems(1);
+        eventData.uintItems.initItems(2);
         eventData.uintItems.setItem(0, "feeAmount", feeAmount);
+        eventData.uintItems.setItem(1, "nextPoolValue", nextPoolValue);
 
         eventEmitter.emitEventLog1(
             "UiFeesClaimed",

--- a/contracts/fee/FeeUtils.sol
+++ b/contracts/fee/FeeUtils.sol
@@ -120,6 +120,8 @@ library FeeUtils {
             feeAmount
         );
 
+        MarketUtils.validateMarketTokenBalance(dataStore, market);
+
         emitFeesClaimed(
             eventEmitter,
             market,
@@ -153,6 +155,8 @@ library FeeUtils {
             receiver,
             feeAmount
         );
+
+        MarketUtils.validateMarketTokenBalance(dataStore, market);
 
         emitUiFeesClaimed(
             eventEmitter,

--- a/contracts/market/MarketEventUtils.sol
+++ b/contracts/market/MarketEventUtils.sol
@@ -333,7 +333,8 @@ library MarketEventUtils {
         address token,
         address account,
         uint256 delta,
-        uint256 nextValue
+        uint256 nextValue,
+        uint256 nextPoolValue
     ) external {
         EventUtils.EventLogData memory eventData;
 
@@ -342,9 +343,10 @@ library MarketEventUtils {
         eventData.addressItems.setItem(1, "token", token);
         eventData.addressItems.setItem(2, "account", account);
 
-        eventData.uintItems.initItems(2);
+        eventData.uintItems.initItems(3);
         eventData.uintItems.setItem(0, "delta", delta);
         eventData.uintItems.setItem(1, "nextValue", nextValue);
+        eventData.uintItems.setItem(2, "nextPoolValue", nextPoolValue);
 
         eventEmitter.emitEventLog1(
             "ClaimableFundingUpdated",
@@ -359,7 +361,8 @@ library MarketEventUtils {
         address token,
         address account,
         address receiver,
-        uint256 amount
+        uint256 amount,
+        uint256 nextPoolValue
     ) external {
         EventUtils.EventLogData memory eventData;
 
@@ -369,8 +372,9 @@ library MarketEventUtils {
         eventData.addressItems.setItem(2, "account", account);
         eventData.addressItems.setItem(3, "receiver", receiver);
 
-        eventData.uintItems.initItems(1);
+        eventData.uintItems.initItems(2);
         eventData.uintItems.setItem(0, "amount", amount);
+        eventData.uintItems.setItem(1, "nextPoolValue", nextPoolValue);
 
         eventEmitter.emitEventLog1(
             "FundingFeesClaimed",
@@ -414,7 +418,8 @@ library MarketEventUtils {
         uint256 timeKey,
         address account,
         uint256 delta,
-        uint256 nextValue
+        uint256 nextValue,
+        uint256 nextPoolValue
     ) external {
         EventUtils.EventLogData memory eventData;
 
@@ -423,10 +428,11 @@ library MarketEventUtils {
         eventData.addressItems.setItem(1, "token", token);
         eventData.addressItems.setItem(2, "account", account);
 
-        eventData.uintItems.initItems(3);
+        eventData.uintItems.initItems(4);
         eventData.uintItems.setItem(0, "timeKey", timeKey);
         eventData.uintItems.setItem(1, "delta", delta);
         eventData.uintItems.setItem(2, "nextValue", nextValue);
+        eventData.uintItems.setItem(3, "nextPoolValue", nextPoolValue);
 
         eventEmitter.emitEventLog1(
             "ClaimableCollateralUpdated",
@@ -442,7 +448,8 @@ library MarketEventUtils {
         uint256 timeKey,
         address account,
         address receiver,
-        uint256 amount
+        uint256 amount,
+        uint256 nextPoolValue
     ) external {
         EventUtils.EventLogData memory eventData;
 
@@ -452,9 +459,10 @@ library MarketEventUtils {
         eventData.addressItems.setItem(2, "account", account);
         eventData.addressItems.setItem(3, "receiver", receiver);
 
-        eventData.uintItems.initItems(2);
+        eventData.uintItems.initItems(3);
         eventData.uintItems.setItem(0, "timeKey", timeKey);
         eventData.uintItems.setItem(1, "amount", amount);
+        eventData.uintItems.setItem(2, "nextPoolValue", nextPoolValue);
 
         eventEmitter.emitEventLog1(
             "CollateralClaimed",

--- a/contracts/order/OrderUtils.sol
+++ b/contracts/order/OrderUtils.sol
@@ -163,6 +163,13 @@ library OrderUtils {
 
         processOrder(params);
 
+        // validate that internal state changes are correct before calling
+        // external callbacks
+        if (params.market.marketToken != address(0)) {
+            MarketUtils.validateMarketTokenBalance(params.contracts.dataStore, params.market);
+        }
+        MarketUtils.validateMarketTokenBalance(params.contracts.dataStore, params.swapPathMarkets);
+
         OrderEventUtils.emitOrderExecuted(params.contracts.eventEmitter, params.key);
 
         CallbackUtils.afterOrderExecution(params.key, params.order);

--- a/contracts/position/PositionUtils.sol
+++ b/contracts/position/PositionUtils.sol
@@ -544,6 +544,7 @@ library PositionUtils {
     ) internal {
         ReferralUtils.incrementAffiliateReward(
             params.contracts.dataStore,
+            params.contracts.eventEmitter,
             params.position.market(),
             params.position.collateralToken(),
             fees.referral.affiliate,

--- a/contracts/referral/ReferralEventUtils.sol
+++ b/contracts/referral/ReferralEventUtils.sol
@@ -15,13 +15,43 @@ library ReferralEventUtils {
     using EventUtils for EventUtils.BytesItems;
     using EventUtils for EventUtils.StringItems;
 
+    function emitAffiliateRewardUpdated(
+        EventEmitter eventEmitter,
+        address market,
+        address token,
+        address affiliate,
+        uint256 delta,
+        uint256 nextValue,
+        uint256 nextPoolValue
+    ) external {
+        EventUtils.EventLogData memory eventData;
+
+        eventData.addressItems.initItems(3);
+        eventData.addressItems.setItem(0, "market", market);
+        eventData.addressItems.setItem(1, "token", token);
+        eventData.addressItems.setItem(2, "affiliate", affiliate);
+
+        eventData.uintItems.initItems(3);
+        eventData.uintItems.setItem(0, "delta", delta);
+        eventData.uintItems.setItem(1, "nextValue", nextValue);
+        eventData.uintItems.setItem(2, "nextPoolValue", nextPoolValue);
+
+        eventEmitter.emitEventLog2(
+            "AffiliateRewardUpdated",
+            Cast.toBytes32(market),
+            Cast.toBytes32(affiliate),
+            eventData
+        );
+    }
+
     function emitAffiliateRewardClaimed(
         EventEmitter eventEmitter,
         address market,
         address token,
         address affiliate,
         address trader,
-        uint256 amount
+        uint256 amount,
+        uint256 nextPoolValue
     ) external {
         EventUtils.EventLogData memory eventData;
 
@@ -31,8 +61,9 @@ library ReferralEventUtils {
         eventData.addressItems.setItem(2, "affiliate", affiliate);
         eventData.addressItems.setItem(3, "trader", trader);
 
-        eventData.uintItems.initItems(1);
+        eventData.uintItems.initItems(2);
         eventData.uintItems.setItem(0, "amount", amount);
+        eventData.uintItems.setItem(1, "nextPoolValue", nextPoolValue);
 
         eventEmitter.emitEventLog1(
             "AffiliateRewardClaimed",

--- a/contracts/referral/ReferralUtils.sol
+++ b/contracts/referral/ReferralUtils.sol
@@ -43,6 +43,7 @@ library ReferralUtils {
     // @param delta The amount to increment the reward balance by.
     function incrementAffiliateReward(
         DataStore dataStore,
+        EventEmitter eventEmitter,
         address market,
         address token,
         address affiliate,
@@ -50,7 +51,18 @@ library ReferralUtils {
     ) internal {
         if (delta == 0) { return; }
 
-        dataStore.incrementUint(Keys.affiliateRewardKey(market, token, affiliate), delta);
+        uint256 nextValue = dataStore.incrementUint(Keys.affiliateRewardKey(market, token, affiliate), delta);
+        uint256 nextPoolValue = dataStore.incrementUint(Keys.affiliateRewardKey(market, token), delta);
+
+        ReferralEventUtils.emitAffiliateRewardUpdated(
+            eventEmitter,
+            market,
+            token,
+            affiliate,
+            delta,
+            nextValue,
+            nextPoolValue
+        );
     }
 
     // @dev Gets the referral information for the specified trader.
@@ -105,6 +117,8 @@ library ReferralUtils {
         uint256 rewardAmount = dataStore.getUint(key);
         dataStore.setUint(key, 0);
 
+        uint256 nextPoolValue = dataStore.decrementUint(Keys.affiliateRewardKey(market, token), rewardAmount);
+
         MarketToken(payable(market)).transferOut(
             token,
             receiver,
@@ -117,7 +131,8 @@ library ReferralUtils {
             token,
             account,
             receiver,
-            rewardAmount
+            rewardAmount,
+            nextPoolValue
         );
     }
 }

--- a/contracts/referral/ReferralUtils.sol
+++ b/contracts/referral/ReferralUtils.sol
@@ -7,6 +7,7 @@ import "../data/Keys.sol";
 
 import "../event/EventEmitter.sol";
 import "../market/MarketToken.sol";
+import "../market/MarketUtils.sol";
 
 import "./IReferralStorage.sol";
 import "./ReferralTier.sol";
@@ -124,6 +125,8 @@ library ReferralUtils {
             receiver,
             rewardAmount
         );
+
+        MarketUtils.validateMarketTokenBalance(dataStore, market);
 
         ReferralEventUtils.emitAffiliateRewardClaimed(
             eventEmitter,

--- a/contracts/withdrawal/WithdrawalUtils.sol
+++ b/contracts/withdrawal/WithdrawalUtils.sol
@@ -410,6 +410,8 @@ library WithdrawalUtils {
             "withdrawal",
             cache.shortTokenFees
         );
+
+        MarketUtils.validateMarketTokenBalance(params.dataStore, market);
     }
 
     function swap(
@@ -441,6 +443,10 @@ library WithdrawalUtils {
                 shouldUnwrapNativeToken // shouldUnwrapNativeToken
             )
         );
+
+        // validate that internal state changes are correct before calling
+        // external callbacks
+        MarketUtils.validateMarketTokenBalance(params.dataStore, swapPathMarkets);
     }
 
     function _getOutputAmounts(

--- a/deploy/deployExchangeRouter.ts
+++ b/deploy/deployExchangeRouter.ts
@@ -21,6 +21,8 @@ const func = createDeployFunction({
     "DepositStoreUtils",
     "WithdrawalStoreUtils",
     "OrderStoreUtils",
+    "MarketStoreUtils",
+    "MarketUtils",
     "MarketEventUtils",
     "ReferralEventUtils",
   ],

--- a/deploy/deployFeeHandler.ts
+++ b/deploy/deployFeeHandler.ts
@@ -9,6 +9,7 @@ const func = createDeployFunction({
   getDeployArgs: async ({ dependencyContracts }) => {
     return constructorContracts.map((dependencyName) => dependencyContracts[dependencyName].address);
   },
+  libraryNames: ["MarketUtils"],
   afterDeploy: async ({ deployedContract }) => {
     await grantRoleIfNotGranted(deployedContract.address, "CONTROLLER");
   },

--- a/deploy/deployIncreasePositionUtils.ts
+++ b/deploy/deployIncreasePositionUtils.ts
@@ -11,6 +11,7 @@ const func = createDeployFunction({
     "PositionStoreUtils",
     "PositionEventUtils",
     "PositionPricingUtils",
+    "ReferralEventUtils",
   ],
 });
 

--- a/deploy/deployOrderUtils.ts
+++ b/deploy/deployOrderUtils.ts
@@ -5,6 +5,7 @@ const func = createDeployFunction({
   libraryNames: [
     "BaseOrderUtils",
     "MarketStoreUtils",
+    "MarketUtils",
     "OrderStoreUtils",
     "OrderEventUtils",
     "IncreaseOrderUtils",

--- a/test/exchange/FundingFees.ts
+++ b/test/exchange/FundingFees.ts
@@ -256,7 +256,7 @@ describe("Exchange.FundingFees", () => {
       execute: {
         afterExecution: async ({ logs }) => {
           const feeInfo = getEventData(logs, "PositionFeesCollected");
-          expect(feeInfo.fundingFeeAmount).eq("806402");
+          expectWithinRange(feeInfo.fundingFeeAmount, "806402", "10");
           expect(feeInfo.collateralToken).eq(usdc.address);
           const claimableFundingData = getEventDataArray(logs, "ClaimableFundingUpdated");
           expect(claimableFundingData.length).eq(0);


### PR DESCRIPTION
Validate that the token balance of a pool is equal to or higher than the tracked pool values, this helps as a sanity check to reduce negative effects in case of incorrect accounting