### PR TITLE
Add code to remove updated at block values

### DIFF
--- a/contracts/deposit/DepositStoreUtils.sol
+++ b/contracts/deposit/DepositStoreUtils.sol
@@ -27,6 +27,7 @@ library DepositStoreUtils {
     bytes32 public constant INITIAL_LONG_TOKEN_AMOUNT = keccak256(abi.encode("INITIAL_LONG_TOKEN_AMOUNT"));
     bytes32 public constant INITIAL_SHORT_TOKEN_AMOUNT = keccak256(abi.encode("INITIAL_SHORT_TOKEN_AMOUNT"));
     bytes32 public constant MIN_MARKET_TOKENS = keccak256(abi.encode("MIN_MARKET_TOKENS"));
+    bytes32 public constant UPDATED_AT_BLOCK = keccak256(abi.encode("UPDATED_AT_BLOCK"));
     bytes32 public constant UPDATED_AT_TIME = keccak256(abi.encode("UPDATED_AT_TIME"));
     bytes32 public constant EXECUTION_FEE = keccak256(abi.encode("EXECUTION_FEE"));
     bytes32 public constant CALLBACK_GAS_LIMIT = keccak256(abi.encode("CALLBACK_GAS_LIMIT"));
@@ -259,6 +260,10 @@ library DepositStoreUtils {
 
         dataStore.removeUint(
             keccak256(abi.encode(key, MIN_MARKET_TOKENS))
+        );
+
+        dataStore.removeUint(
+            keccak256(abi.encode(key, UPDATED_AT_BLOCK))
         );
 
         dataStore.removeUint(

--- a/contracts/order/OrderStoreUtils.sol
+++ b/contracts/order/OrderStoreUtils.sol
@@ -33,6 +33,7 @@ library OrderStoreUtils {
     bytes32 public constant CALLBACK_GAS_LIMIT = keccak256(abi.encode("CALLBACK_GAS_LIMIT"));
     bytes32 public constant MIN_OUTPUT_AMOUNT = keccak256(abi.encode("MIN_OUTPUT_AMOUNT"));
     bytes32 public constant VALID_FROM_TIME = keccak256(abi.encode("VALID_FROM_TIME"));
+    bytes32 public constant UPDATED_AT_BLOCK = keccak256(abi.encode("UPDATED_AT_BLOCK"));
     bytes32 public constant UPDATED_AT_TIME = keccak256(abi.encode("UPDATED_AT_TIME"));
 
     bytes32 public constant IS_LONG = keccak256(abi.encode("IS_LONG"));
@@ -353,6 +354,10 @@ library OrderStoreUtils {
 
         dataStore.removeUint(
             keccak256(abi.encode(key, VALID_FROM_TIME))
+        );
+
+        dataStore.removeUint(
+            keccak256(abi.encode(key, UPDATED_AT_BLOCK))
         );
 
         dataStore.removeUint(

--- a/contracts/withdrawal/WithdrawalStoreUtils.sol
+++ b/contracts/withdrawal/WithdrawalStoreUtils.sol
@@ -25,6 +25,7 @@ library WithdrawalStoreUtils {
     bytes32 public constant MARKET_TOKEN_AMOUNT = keccak256(abi.encode("MARKET_TOKEN_AMOUNT"));
     bytes32 public constant MIN_LONG_TOKEN_AMOUNT = keccak256(abi.encode("MIN_LONG_TOKEN_AMOUNT"));
     bytes32 public constant MIN_SHORT_TOKEN_AMOUNT = keccak256(abi.encode("MIN_SHORT_TOKEN_AMOUNT"));
+    bytes32 public constant UPDATED_AT_BLOCK = keccak256(abi.encode("UPDATED_AT_BLOCK"));
     bytes32 public constant UPDATED_AT_TIME = keccak256(abi.encode("UPDATED_AT_TIME"));
     bytes32 public constant EXECUTION_FEE = keccak256(abi.encode("EXECUTION_FEE"));
     bytes32 public constant CALLBACK_GAS_LIMIT = keccak256(abi.encode("CALLBACK_GAS_LIMIT"));
@@ -231,6 +232,10 @@ library WithdrawalStoreUtils {
 
         dataStore.removeUint(
             keccak256(abi.encode(key, MIN_SHORT_TOKEN_AMOUNT))
+        );
+
+        dataStore.removeUint(
+            keccak256(abi.encode(key, UPDATED_AT_BLOCK))
         );
 
         dataStore.removeUint(


### PR DESCRIPTION
When updated contracts from https://github.com/gmx-io/gmx-synthetics/pull/50/files are deployed, the previous contracts would still be functional, these contracts would continue to write block values to the DataStore

These block values should continue to be removed in the updated contracts to avoid dangling values in the DataStore
