### PR TITLE
Remove setting of position increasedAtBlock and decreasedAtBlock to save gas

### DIFF
--- a/contracts/position/DecreasePositionUtils.sol
+++ b/contracts/position/DecreasePositionUtils.sol
@@ -249,7 +249,6 @@ library DecreasePositionUtils {
         params.position.setSizeInUsd(cache.nextPositionSizeInUsd);
         params.position.setSizeInTokens(params.position.sizeInTokens() - values.sizeDeltaInTokens);
         params.position.setCollateralAmount(values.remainingCollateralAmount);
-        params.position.setDecreasedAtBlock(Chain.currentBlockNumber());
         params.position.setDecreasedAtTime(Chain.currentTimestamp());
 
         PositionUtils.incrementClaimableFundingAmount(params, fees);

--- a/contracts/position/IncreasePositionUtils.sol
+++ b/contracts/position/IncreasePositionUtils.sol
@@ -151,7 +151,6 @@ library IncreasePositionUtils {
         params.position.setShortTokenClaimableFundingAmountPerSize(fees.funding.latestShortTokenClaimableFundingAmountPerSize);
 
         params.position.setBorrowingFactor(cache.nextPositionBorrowingFactor);
-        params.position.setIncreasedAtBlock(Chain.currentBlockNumber());
         params.position.setIncreasedAtTime(Chain.currentTimestamp());
 
         PositionStoreUtils.set(params.contracts.dataStore, params.positionKey, params.position);

--- a/contracts/position/Position.sol
+++ b/contracts/position/Position.sol
@@ -59,8 +59,8 @@ library Position {
     // for the market.longToken
     // @param shortTokenClaimableFundingAmountPerSize the position's claimable funding amount per size
     // for the market.shortToken
-    // @param increasedAtBlock the block at which the position was last increased
-    // @param decreasedAtBlock the block at which the position was last decreased
+    // @param increasedAtTime the time at which this position was increased
+    // @param decreasedAtTime the time at which this position was decreased
     struct Numbers {
         uint256 sizeInUsd;
         uint256 sizeInTokens;
@@ -69,8 +69,6 @@ library Position {
         uint256 fundingFeeAmountPerSize;
         uint256 longTokenClaimableFundingAmountPerSize;
         uint256 shortTokenClaimableFundingAmountPerSize;
-        uint256 increasedAtBlock;
-        uint256 decreasedAtBlock;
         uint256 increasedAtTime;
         uint256 decreasedAtTime;
     }
@@ -158,22 +156,6 @@ library Position {
 
     function setShortTokenClaimableFundingAmountPerSize(Props memory props, uint256 value) internal pure {
         props.numbers.shortTokenClaimableFundingAmountPerSize = value;
-    }
-
-    function increasedAtBlock(Props memory props) internal pure returns (uint256) {
-        return props.numbers.increasedAtBlock;
-    }
-
-    function setIncreasedAtBlock(Props memory props, uint256 value) internal pure {
-        props.numbers.increasedAtBlock = value;
-    }
-
-    function decreasedAtBlock(Props memory props) internal pure returns (uint256) {
-        return props.numbers.decreasedAtBlock;
-    }
-
-    function setDecreasedAtBlock(Props memory props, uint256 value) internal pure {
-        props.numbers.decreasedAtBlock = value;
     }
 
     function increasedAtTime(Props memory props) internal pure returns (uint256) {

--- a/contracts/position/PositionStoreUtils.sol
+++ b/contracts/position/PositionStoreUtils.sol
@@ -25,8 +25,6 @@ library PositionStoreUtils {
     bytes32 public constant FUNDING_FEE_AMOUNT_PER_SIZE = keccak256(abi.encode("FUNDING_FEE_AMOUNT_PER_SIZE"));
     bytes32 public constant LONG_TOKEN_CLAIMABLE_FUNDING_AMOUNT_PER_SIZE = keccak256(abi.encode("LONG_TOKEN_CLAIMABLE_FUNDING_AMOUNT_PER_SIZE"));
     bytes32 public constant SHORT_TOKEN_CLAIMABLE_FUNDING_AMOUNT_PER_SIZE = keccak256(abi.encode("SHORT_TOKEN_CLAIMABLE_FUNDING_AMOUNT_PER_SIZE"));
-    bytes32 public constant INCREASED_AT_BLOCK = keccak256(abi.encode("INCREASED_AT_BLOCK"));
-    bytes32 public constant DECREASED_AT_BLOCK = keccak256(abi.encode("DECREASED_AT_BLOCK"));
     bytes32 public constant INCREASED_AT_TIME = keccak256(abi.encode("INCREASED_AT_TIME"));
     bytes32 public constant DECREASED_AT_TIME = keccak256(abi.encode("DECREASED_AT_TIME"));
 
@@ -223,14 +221,6 @@ library PositionStoreUtils {
 
         dataStore.removeUint(
             keccak256(abi.encode(key, SHORT_TOKEN_CLAIMABLE_FUNDING_AMOUNT_PER_SIZE))
-        );
-
-        dataStore.removeUint(
-            keccak256(abi.encode(key, INCREASED_AT_BLOCK))
-        );
-
-        dataStore.removeUint(
-            keccak256(abi.encode(key, DECREASED_AT_BLOCK))
         );
 
         dataStore.removeUint(

--- a/contracts/position/PositionStoreUtils.sol
+++ b/contracts/position/PositionStoreUtils.sol
@@ -78,14 +78,6 @@ library PositionStoreUtils {
             keccak256(abi.encode(key, SHORT_TOKEN_CLAIMABLE_FUNDING_AMOUNT_PER_SIZE))
         ));
 
-        position.setIncreasedAtBlock(dataStore.getUint(
-            keccak256(abi.encode(key, INCREASED_AT_BLOCK))
-        ));
-
-        position.setDecreasedAtBlock(dataStore.getUint(
-            keccak256(abi.encode(key, DECREASED_AT_BLOCK))
-        ));
-
         position.setIncreasedAtTime(dataStore.getUint(
             keccak256(abi.encode(key, INCREASED_AT_TIME))
         ));
@@ -160,16 +152,6 @@ library PositionStoreUtils {
         dataStore.setUint(
             keccak256(abi.encode(key, SHORT_TOKEN_CLAIMABLE_FUNDING_AMOUNT_PER_SIZE)),
             position.shortTokenClaimableFundingAmountPerSize()
-        );
-
-        dataStore.setUint(
-            keccak256(abi.encode(key, INCREASED_AT_BLOCK)),
-            position.increasedAtBlock()
-        );
-
-        dataStore.setUint(
-            keccak256(abi.encode(key, DECREASED_AT_BLOCK)),
-            position.decreasedAtBlock()
         );
 
         dataStore.setUint(


### PR DESCRIPTION
The code to delete the increasedAtBlock and decreasedAtBlock values has been left as is, reason: https://github.com/gmx-io/gmx-synthetics/pull/59