### PR TITLE
Refactor glv deposit utils to reduce bytecode size

### DIFF
--- a/contracts/glv/glvDeposit/GlvDepositCalc.sol
+++ b/contracts/glv/glvDeposit/GlvDepositCalc.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.0;
 import "./GlvDeposit.sol";
 import "../GlvUtils.sol";
 
-library GlvDepositHelper {
+library GlvDepositCalc {
     using GlvDeposit for GlvDeposit.Props;
     using SafeCast for int256;
 

--- a/contracts/glv/glvDeposit/GlvDepositHelper.sol
+++ b/contracts/glv/glvDeposit/GlvDepositHelper.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity ^0.8.0;
+
+import "./GlvDeposit.sol";
+import "../GlvUtils.sol";
+
+library GlvDepositHelper {
+    using GlvDeposit for GlvDeposit.Props;
+    using SafeCast for int256;
+
+    address public constant RECEIVER_FOR_FIRST_GLV_DEPOSIT = address(1);
+
+    function validateFirstGlvDeposit(
+        DataStore dataStore,
+        GlvDeposit.Props memory glvDeposit
+    ) external view {
+        address glv = glvDeposit.glv();
+        uint256 initialGlvTokenSupply = GlvToken(payable(glv)).totalSupply();
+
+        // return if this is not the first glv deposit
+        if (initialGlvTokenSupply != 0) {
+            return;
+        }
+
+        uint256 minGlvTokens = dataStore.getUint(Keys.minGlvTokensForFirstGlvDepositKey(glv));
+
+        // return if there is no minGlvTokens requirement
+        if (minGlvTokens == 0) {
+            return;
+        }
+
+        if (glvDeposit.receiver() != RECEIVER_FOR_FIRST_GLV_DEPOSIT) {
+            revert Errors.InvalidReceiverForFirstGlvDeposit(glvDeposit.receiver(), RECEIVER_FOR_FIRST_GLV_DEPOSIT);
+        }
+
+        if (glvDeposit.minGlvTokens() < minGlvTokens) {
+            revert Errors.InvalidMinGlvTokensForFirstGlvDeposit(glvDeposit.minGlvTokens(), minGlvTokens);
+        }
+    }
+
+    function getMintAmount(
+        DataStore dataStore,
+        Oracle oracle,
+        GlvDeposit.Props memory glvDeposit,
+        uint256 receivedMarketTokens,
+        uint256 glvValue,
+        uint256 glvSupply
+    ) external view returns (uint256) {
+        Market.Props memory market = MarketUtils.getEnabledMarket(dataStore, glvDeposit.market());
+        MarketPoolValueInfo.Props memory poolValueInfo = MarketUtils.getPoolValueInfo(
+            dataStore,
+            market,
+            oracle.getPrimaryPrice(market.indexToken),
+            oracle.getPrimaryPrice(market.longToken),
+            oracle.getPrimaryPrice(market.shortToken),
+            Keys.MAX_PNL_FACTOR_FOR_DEPOSITS,
+            false // maximize
+        );
+        uint256 marketTokenSupply = MarketUtils.getMarketTokenSupply(MarketToken(payable(market.marketToken)));
+        uint256 receivedMarketTokensUsd = MarketUtils.marketTokenAmountToUsd(
+            receivedMarketTokens,
+            poolValueInfo.poolValue.toUint256(),
+            marketTokenSupply
+        );
+        return GlvUtils.usdToGlvTokenAmount(receivedMarketTokensUsd, glvValue, glvSupply);
+    }
+}

--- a/contracts/glv/glvDeposit/GlvDepositUtils.sol
+++ b/contracts/glv/glvDeposit/GlvDepositUtils.sol
@@ -10,7 +10,7 @@ import "../GlvVault.sol";
 import "../GlvUtils.sol";
 import "./GlvDepositEventUtils.sol";
 import "./GlvDepositStoreUtils.sol";
-import "./GlvDepositHelper.sol";
+import "./GlvDepositCalc.sol";
 
 library GlvDepositUtils {
     using GlvDeposit for GlvDeposit.Props;
@@ -215,7 +215,7 @@ library GlvDepositUtils {
         GlvDepositStoreUtils.remove(params.dataStore, params.key, glvDeposit.account());
 
         // should be called before any tokens are minted
-        GlvDepositHelper.validateFirstGlvDeposit(params.dataStore, glvDeposit);
+        GlvDepositCalc.validateFirstGlvDeposit(params.dataStore, glvDeposit);
 
         ExecuteGlvDepositCache memory cache;
 
@@ -233,7 +233,7 @@ library GlvDepositUtils {
         GlvToken(payable(glvDeposit.glv())).syncTokenBalance(glvDeposit.market());
 
         cache.glvSupply = GlvToken(payable(glvDeposit.glv())).totalSupply();
-        cache.mintAmount = GlvDepositHelper.getMintAmount(
+        cache.mintAmount = GlvDepositCalc.getMintAmount(
             params.dataStore,
             params.oracle,
             glvDeposit,

--- a/contracts/glv/glvDeposit/GlvDepositUtils.sol
+++ b/contracts/glv/glvDeposit/GlvDepositUtils.sol
@@ -10,6 +10,7 @@ import "../GlvVault.sol";
 import "../GlvUtils.sol";
 import "./GlvDepositEventUtils.sol";
 import "./GlvDepositStoreUtils.sol";
+import "./GlvDepositHelper.sol";
 
 library GlvDepositUtils {
     using GlvDeposit for GlvDeposit.Props;
@@ -214,7 +215,7 @@ library GlvDepositUtils {
         GlvDepositStoreUtils.remove(params.dataStore, params.key, glvDeposit.account());
 
         // should be called before any tokens are minted
-        _validateFirstGlvDeposit(params, glvDeposit);
+        GlvDepositHelper.validateFirstGlvDeposit(params.dataStore, glvDeposit);
 
         ExecuteGlvDepositCache memory cache;
 
@@ -232,7 +233,7 @@ library GlvDepositUtils {
         GlvToken(payable(glvDeposit.glv())).syncTokenBalance(glvDeposit.market());
 
         cache.glvSupply = GlvToken(payable(glvDeposit.glv())).totalSupply();
-        cache.mintAmount = _getMintAmount(
+        cache.mintAmount = GlvDepositHelper.getMintAmount(
             params.dataStore,
             params.oracle,
             glvDeposit,
@@ -308,60 +309,6 @@ library GlvDepositUtils {
         return cache.mintAmount;
     }
 
-    function _validateFirstGlvDeposit(
-        ExecuteGlvDepositParams memory params,
-        GlvDeposit.Props memory glvDeposit
-    ) internal view {
-        address glv = glvDeposit.glv();
-        uint256 initialGlvTokenSupply = GlvToken(payable(glv)).totalSupply();
-
-        // return if this is not the first glv deposit
-        if (initialGlvTokenSupply != 0) {
-            return;
-        }
-
-        uint256 minGlvTokens = params.dataStore.getUint(Keys.minGlvTokensForFirstGlvDepositKey(glv));
-
-        // return if there is no minGlvTokens requirement
-        if (minGlvTokens == 0) {
-            return;
-        }
-
-        if (glvDeposit.receiver() != RECEIVER_FOR_FIRST_GLV_DEPOSIT) {
-            revert Errors.InvalidReceiverForFirstGlvDeposit(glvDeposit.receiver(), RECEIVER_FOR_FIRST_GLV_DEPOSIT);
-        }
-
-        if (glvDeposit.minGlvTokens() < minGlvTokens) {
-            revert Errors.InvalidMinGlvTokensForFirstGlvDeposit(glvDeposit.minGlvTokens(), minGlvTokens);
-        }
-    }
-
-    function _getMintAmount(
-        DataStore dataStore,
-        Oracle oracle,
-        GlvDeposit.Props memory glvDeposit,
-        uint256 receivedMarketTokens,
-        uint256 glvValue,
-        uint256 glvSupply
-    ) internal view returns (uint256) {
-        Market.Props memory market = MarketUtils.getEnabledMarket(dataStore, glvDeposit.market());
-        MarketPoolValueInfo.Props memory poolValueInfo = MarketUtils.getPoolValueInfo(
-            dataStore,
-            market,
-            oracle.getPrimaryPrice(market.indexToken),
-            oracle.getPrimaryPrice(market.longToken),
-            oracle.getPrimaryPrice(market.shortToken),
-            Keys.MAX_PNL_FACTOR_FOR_DEPOSITS,
-            false // maximize
-        );
-        uint256 marketTokenSupply = MarketUtils.getMarketTokenSupply(MarketToken(payable(market.marketToken)));
-        uint256 receivedMarketTokensUsd = MarketUtils.marketTokenAmountToUsd(
-            receivedMarketTokens,
-            poolValueInfo.poolValue.toUint256(),
-            marketTokenSupply
-        );
-        return GlvUtils.usdToGlvTokenAmount(receivedMarketTokensUsd, glvValue, glvSupply);
-    }
 
     function _processMarketDeposit(
         ExecuteGlvDepositParams memory params,

--- a/deploy/deployGlvDepositHelper.ts
+++ b/deploy/deployGlvDepositHelper.ts
@@ -1,7 +1,7 @@
 import { createDeployFunction } from "../utils/deploy";
 
 const func = createDeployFunction({
-  contractName: "GlvDepositHelper",
+  contractName: "GlvDepositCalc",
   libraryNames: ["MarketUtils", "MarketStoreUtils"],
 });
 

--- a/deploy/deployGlvDepositHelper.ts
+++ b/deploy/deployGlvDepositHelper.ts
@@ -1,0 +1,8 @@
+import { createDeployFunction } from "../utils/deploy";
+
+const func = createDeployFunction({
+  contractName: "GlvDepositHelper",
+  libraryNames: ["MarketUtils", "MarketStoreUtils"],
+});
+
+export default func;

--- a/deploy/deployGlvDepositUtils.ts
+++ b/deploy/deployGlvDepositUtils.ts
@@ -10,6 +10,7 @@ const func = createDeployFunction({
     "GasUtils",
     "GlvDepositEventUtils",
     "GlvDepositStoreUtils",
+    "GlvDepositHelper",
     "MarketStoreUtils",
   ],
 });

--- a/deploy/deployGlvDepositUtils.ts
+++ b/deploy/deployGlvDepositUtils.ts
@@ -10,7 +10,7 @@ const func = createDeployFunction({
     "GasUtils",
     "GlvDepositEventUtils",
     "GlvDepositStoreUtils",
-    "GlvDepositHelper",
+    "GlvDepositCalc",
     "MarketStoreUtils",
   ],
 });

--- a/utils/fixture.ts
+++ b/utils/fixture.ts
@@ -79,6 +79,7 @@ export async function deployFixture() {
   const glvHandler = await hre.ethers.getContract("GlvHandler");
   const glvRouter = await hre.ethers.getContract("GlvRouter");
   const glvDepositStoreUtils = await hre.ethers.getContract("GlvDepositStoreUtils");
+  const glvDepositHelper = await hre.ethers.getContract("GlvDepositHelper");
   const glvWithdrawalStoreUtils = await hre.ethers.getContract("GlvWithdrawalStoreUtils");
   const glvShiftStoreUtils = await hre.ethers.getContract("GlvShiftStoreUtils");
   const glvStoreUtils = await hre.ethers.getContract("GlvStoreUtils");
@@ -316,6 +317,7 @@ export async function deployFixture() {
       glvRouter,
       ethUsdGlvAddress,
       glvDepositStoreUtils,
+      glvDepositHelper,
       glvWithdrawalStoreUtils,
       glvShiftStoreUtils,
       glvStoreUtils,

--- a/utils/fixture.ts
+++ b/utils/fixture.ts
@@ -79,7 +79,7 @@ export async function deployFixture() {
   const glvHandler = await hre.ethers.getContract("GlvHandler");
   const glvRouter = await hre.ethers.getContract("GlvRouter");
   const glvDepositStoreUtils = await hre.ethers.getContract("GlvDepositStoreUtils");
-  const glvDepositHelper = await hre.ethers.getContract("GlvDepositHelper");
+  const GlvDepositCalc = await hre.ethers.getContract("GlvDepositCalc");
   const glvWithdrawalStoreUtils = await hre.ethers.getContract("GlvWithdrawalStoreUtils");
   const glvShiftStoreUtils = await hre.ethers.getContract("GlvShiftStoreUtils");
   const glvStoreUtils = await hre.ethers.getContract("GlvStoreUtils");
@@ -317,7 +317,7 @@ export async function deployFixture() {
       glvRouter,
       ethUsdGlvAddress,
       glvDepositStoreUtils,
-      glvDepositHelper,
+      GlvDepositCalc,
       glvWithdrawalStoreUtils,
       glvShiftStoreUtils,
       glvStoreUtils,


### PR DESCRIPTION
Moved _validateFirstGlvDeposit and _getMintAmount internal methods from GlvDepositUtils to the newly created GlvDepositHelper library.