### PR TITLE
Verify tokens before listings (ERC777 and upgradeability)

### DIFF
--- a/config/tokens.ts
+++ b/config/tokens.ts
@@ -1247,11 +1247,6 @@ const config: {
         stablePrice: decimalToFloat(1),
       },
     },
-    GLV_WETH_USDC: {
-      address: "0x528A5bac7E746C9A509A1f4F6dF58A03d44279F9",
-      decimals: 18,
-      transferGasLimit: 200 * 1000,
-    },
   },
   arbitrumGoerli: {
     WETH: {

--- a/scripts/initOracleConfigForTokensUtils.ts
+++ b/scripts/initOracleConfigForTokensUtils.ts
@@ -10,8 +10,11 @@ import * as keys from "../utils/keys";
 import { getOracleProviderAddress } from "../utils/oracle";
 
 import IPriceFeed from "../artifacts/contracts/oracle/IPriceFeed.sol/IPriceFeed.json";
+import { validateTickers } from "./validateTickersUtils";
 
 export async function initOracleConfigForTokens({ write }) {
+  await validateTickers();
+
   const tokens = await hre.gmx.getTokens();
 
   const dataStore = await hre.ethers.getContract("DataStore");

--- a/scripts/updateTokenConfig.ts
+++ b/scripts/updateTokenConfig.ts
@@ -4,6 +4,7 @@ import { validateMarketConfigs } from "./validateMarketConfigsUtils";
 import { encodeData } from "../utils/hash";
 import { ConfigChangeItem, handleConfigChanges } from "./updateConfigUtils";
 import * as keys from "../utils/keys";
+import { validatePriceFeeds } from "./validatePriceFeedsUtils";
 
 const processTokens = async ({ tokens }): Promise<ConfigChangeItem[]> => {
   const configItems: ConfigChangeItem[] = [];
@@ -53,6 +54,8 @@ async function main() {
       throw new Error("Invalid market configs");
     }
   }
+
+  await validatePriceFeeds(); // which validates the tokens as well
 
   const tokens = await hre.gmx.getTokens();
   const configItems = await processTokens({ tokens });

--- a/scripts/updateTokenConfig.ts
+++ b/scripts/updateTokenConfig.ts
@@ -4,7 +4,7 @@ import { validateMarketConfigs } from "./validateMarketConfigsUtils";
 import { encodeData } from "../utils/hash";
 import { ConfigChangeItem, handleConfigChanges } from "./updateConfigUtils";
 import * as keys from "../utils/keys";
-import { validateTickers } from "./validateTickersUtils";
+import { validateTokens } from "./validateTokenUtils";
 
 const processTokens = async ({ tokens }): Promise<ConfigChangeItem[]> => {
   const configItems: ConfigChangeItem[] = [];
@@ -55,7 +55,7 @@ async function main() {
     }
   }
 
-  await validateTickers();
+  await validateTokens();
 
   const tokens = await hre.gmx.getTokens();
   const configItems = await processTokens({ tokens });

--- a/scripts/updateTokenConfig.ts
+++ b/scripts/updateTokenConfig.ts
@@ -4,7 +4,7 @@ import { validateMarketConfigs } from "./validateMarketConfigsUtils";
 import { encodeData } from "../utils/hash";
 import { ConfigChangeItem, handleConfigChanges } from "./updateConfigUtils";
 import * as keys from "../utils/keys";
-import { validatePriceFeeds } from "./validatePriceFeedsUtils";
+import { validateTickers } from "./validateTickersUtils";
 
 const processTokens = async ({ tokens }): Promise<ConfigChangeItem[]> => {
   const configItems: ConfigChangeItem[] = [];
@@ -55,7 +55,7 @@ async function main() {
     }
   }
 
-  await validatePriceFeeds(); // which validates the tokens as well
+  await validateTickers();
 
   const tokens = await hre.gmx.getTokens();
   const configItems = await processTokens({ tokens });

--- a/scripts/validateTickers.ts
+++ b/scripts/validateTickers.ts
@@ -1,7 +1,7 @@
-import { validatePriceFeeds } from "./validatePriceFeedsUtils";
+import { validateTickers } from "./validateTickersUtils";
 
 async function main() {
-  await validatePriceFeeds();
+  await validateTickers();
 }
 
 main()

--- a/scripts/validateTickersUtils.ts
+++ b/scripts/validateTickersUtils.ts
@@ -121,7 +121,7 @@ async function validateRealtimeFeedConfig({
   return { shouldUpdate: true, realtimeFeedMultiplier };
 }
 
-export async function validatePriceFeeds() {
+export async function validateTickers() {
   if (process.env.SKIP_TOKEN_VALIDATION === undefined) {
     await validateTokens();
   }

--- a/scripts/validateTickersUtils.ts
+++ b/scripts/validateTickersUtils.ts
@@ -122,10 +122,6 @@ async function validateRealtimeFeedConfig({
 }
 
 export async function validateTickers() {
-  if (process.env.SKIP_TOKEN_VALIDATION === undefined) {
-    await validateTokens();
-  }
-
   const dataStore = await hre.ethers.getContract("DataStore");
   const clientId = process.env.REALTIME_FEED_CLIENT_ID;
   const clientSecret = process.env.REALTIME_FEED_CLIENT_SECRET;

--- a/scripts/validateTokenUtils.ts
+++ b/scripts/validateTokenUtils.ts
@@ -1,10 +1,98 @@
+import { setTimeout as sleep } from "timers/promises";
 import hre from "hardhat";
+import { getExplorerUrl } from "../hardhat.config";
+import got from "got";
+
+const { ethers } = hre;
+
+const ERC1820_REGISTRY = "0x1820a4B7618BdE71Dce8cdc73aAB6C95905faD24";
+const ERC1820_ABI = [
+  "function getInterfaceImplementer(address account, bytes32 interfaceHash) external view returns (address)",
+];
+// Hash of "ERC777Token" per ERC-1820 spec
+const ERC777_INTERFACE_HASH = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("ERC777Token"));
+
+const IMPLEMENTATION_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
+// const ADMIN_SLOT = "0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103"; // admin-based behavior isn’t  different for callback detection and ERC777 check, so no need to take different actions based on proxy type
+const BEACON_SLOT = "0xa3f0ad74e5424f2d3d81c7cdd48ab208b5bfa6d06c18a42f3b72a1f3eab72c36";
+
+const callbackFunctionNames = [
+  "onTokenReceived",
+  "onTransferReceived",
+  "tokensReceived",
+  "tokensToSend",
+  "transferAndCall",
+  "approveAndCall",
+];
+
+async function fetchAbi(address) {
+  const apiUrl = getExplorerUrl(hre.network.name);
+  const apiKey = hre.network.config.verify.etherscan.apiKey;
+  const res: any = await got
+    .get(`${apiUrl}api`, {
+      searchParams: {
+        module: "contract",
+        action: "getabi",
+        address,
+        apikey: apiKey,
+      },
+    })
+    .json();
+
+  if (res.status !== "1") {
+    throw new Error("Failed to fetch ABI from Etherscan.");
+  }
+
+  await sleep(200);
+  return JSON.parse(res.result);
+}
+
+async function detectCallbackFunctions(address) {
+  const abi = await fetchAbi(address);
+  const iface = new ethers.utils.Interface(abi);
+  const functions = Object.keys(iface.functions);
+
+  return functions.filter((fn) => callbackFunctionNames.some((name) => fn.includes(name)));
+}
+
+export async function isErc777Token(tokenAddress) {
+  const provider = ethers.provider;
+  const registry = new ethers.Contract(ERC1820_REGISTRY, ERC1820_ABI, provider);
+
+  const implementer = await registry.getInterfaceImplementer(tokenAddress, ERC777_INTERFACE_HASH);
+
+  return implementer !== ethers.constants.AddressZero;
+}
+
+function parseAddress(slot) {
+  return ethers.utils.getAddress(`0x${slot.slice(-40)}`);
+}
+
+async function getBeaconImplementation(beaconAddress) {
+  try {
+    const beacon = new ethers.Contract(
+      beaconAddress,
+      ["function implementation() view returns (address)"],
+      ethers.provider
+    );
+    return await beacon.implementation();
+  } catch {
+    return null;
+  }
+}
 
 export async function validateTokens() {
   const tokens = await hre.gmx.getTokens();
   console.log(`validating ${Object.entries(tokens).length} tokens ...`);
 
+  const errors = [];
+
   for (const [tokenSymbol, token] of Object.entries(tokens)) {
+    let upgradeability = null;
+    let implementationAddress = null;
+
+    console.log("");
+
     if (!token.decimals) {
       throw new Error(`token ${tokenSymbol} has no decimals`);
     }
@@ -25,7 +113,58 @@ export async function validateTokens() {
         `invalid token decimals for ${tokenSymbol}, configuration: ${token.decimals}, fetched: ${decimals}`
       );
     }
-  }
 
-  console.log(`... validated ${Object.entries(tokens).length} tokens`);
+    const isErc777 = await isErc777Token(token.address);
+    console.log(`isErc777: ${isErc777}`);
+    if (isErc777) {
+      errors.push(`${tokenSymbol} is an ERC777 token`);
+    }
+
+    const callbacks = await detectCallbackFunctions(token.address);
+    console.log(`hasCallbacks: ${callbacks.length > 0}`);
+
+    if (callbacks.length > 0) {
+      errors.push(`${tokenSymbol} hasCallbacks: ${callbacks.join(",")}`);
+    }
+
+    const implSlot = await ethers.provider.getStorageAt(token.address, IMPLEMENTATION_SLOT);
+    const beaconSlot = await ethers.provider.getStorageAt(token.address, BEACON_SLOT);
+
+    if (beaconSlot !== ethers.constants.HashZero) {
+      upgradeability = "beacon";
+      implementationAddress = await getBeaconImplementation(parseAddress(beaconSlot));
+    } else if (implSlot !== ethers.constants.HashZero) {
+      upgradeability = "transparent or uups";
+      implementationAddress = parseAddress(implSlot);
+    }
+
+    if (implementationAddress) {
+      console.log(`upgradeable: ${upgradeability}`);
+      console.log(`implementation: ${implementationAddress}`);
+
+      const implCallbacks = await detectCallbackFunctions(implementationAddress);
+      console.log(`implHasCallbacks: ${implCallbacks.length > 0}`);
+      if (implCallbacks.length > 0) {
+        errors.push(`${tokenSymbol} implHasCallbacks: ${implCallbacks.join(",")}`);
+      }
+    }
+  }
+  console.log(`\n... validated ${Object.entries(tokens).length} tokens`);
+  console.log(`\nerrors: ${errors.length}`);
+  for (const error of errors) {
+    console.log(`error: ${error}`);
+  }
 }
+
+async function main() {
+  await validateTokens();
+}
+
+main()
+  .then(() => {
+    process.exit(0);
+  })
+  .catch((ex) => {
+    console.error(ex);
+    process.exit(1);
+  });

--- a/scripts/validateTokenUtils.ts
+++ b/scripts/validateTokenUtils.ts
@@ -98,14 +98,12 @@ async function getBeaconImplementation(beaconAddress) {
 
 export async function validateTokens() {
   const tokens = await hre.gmx.getTokens();
-  console.log(`validating ${Object.entries(tokens).length} tokens ...`);
+  console.log(`\nValidating ${Object.entries(tokens).length} tokens ...`);
 
   const errors = [];
   const warnings = [];
 
   for (const [tokenSymbol, token] of Object.entries(tokens)) {
-    console.log("");
-
     if (whitelistedTokens[hre.network.name].includes(tokenSymbol)) {
       console.log(`skipping ${tokenSymbol} as it is whitelisted`);
       continue;
@@ -133,13 +131,13 @@ export async function validateTokens() {
     }
 
     const isErc777 = await isErc777Token(token.address);
-    console.log(`isErc777: ${isErc777}`);
+    console.log(`   isErc777: ${isErc777}`);
     if (isErc777) {
       errors.push(`${tokenSymbol} is an ERC777 token`);
     }
 
     const callbacks = await detectCallbackFunctions(token.address);
-    console.log(`hasCallbacks: ${callbacks.length > 0}`);
+    console.log(`   hasCallbacks: ${callbacks.length > 0}`);
 
     if (callbacks.length > 0) {
       errors.push(`${tokenSymbol} hasCallbacks: ${callbacks.join(",")}`);
@@ -160,11 +158,11 @@ export async function validateTokens() {
     }
 
     if (implementationAddress) {
-      console.log(`upgradeable: ${upgradeability}`);
-      console.log(`implementation: ${implementationAddress}`);
+      console.log(`   upgradeable: ${upgradeability}`);
+      console.log(`   implementation: ${implementationAddress}`);
 
       const implCallbacks = await detectCallbackFunctions(implementationAddress);
-      console.log(`implHasCallbacks: ${implCallbacks.length > 0}`);
+      console.log(`   implHasCallbacks: ${implCallbacks.length > 0}`);
       if (implCallbacks.length > 0) {
         errors.push(`${tokenSymbol} implHasCallbacks: ${implCallbacks.join(",")}`);
       } else {
@@ -172,33 +170,20 @@ export async function validateTokens() {
       }
     }
   }
-  console.log(`\n... validated ${Object.entries(tokens).length} tokens`);
+  console.log(`... validated ${Object.entries(tokens).length} tokens`);
 
-  console.log(`\nwarnings: ${warnings.length}`);
+  console.log(`warnings: ${warnings.length}`);
   for (const warning of warnings) {
     console.log(`⚠️ ${warning}`);
   }
 
-  console.log(`\nerrors: ${errors.length}`);
+  console.log(`errors: ${errors.length}`);
   for (const error of errors) {
     console.log(`🛑 ${error}`);
   }
   if (errors.length == 0) {
-    console.log("\n✅ All tokens are valid");
+    console.log("✅ All tokens are valid.\n");
   } else {
-    throw new Error(`\n🛑 Validation failed for ${errors.length} tokens`);
+    throw new Error(`🛑 Validation failed for ${errors.length} tokens`);
   }
 }
-
-async function main() {
-  await validateTokens();
-}
-
-main()
-  .then(() => {
-    process.exit(0);
-  })
-  .catch((ex) => {
-    console.error(ex);
-    process.exit(1);
-  });

--- a/utils/prices.ts
+++ b/utils/prices.ts
@@ -27,6 +27,10 @@ export function getTickersUrl() {
     return "https://avalanche-api.gmxinfra.io/prices/tickers";
   }
 
+  if (hre.network.name === "botanix") {
+    return "https://botanix-api.gmxinfra.io/prices/tickers";
+  }
+
   throw new Error("Unsupported network");
 }
 


### PR DESCRIPTION
1. validateTokens is now checking: 
- is Erc777
- has callbacks
- is upgradeable (and if it is, then checks for callbacks on the implementation)
- if any validations fail, it prints them, and throws an error

2. validateTokens is called in updateTokenConfig.ts
and if network == botanix
- checks if there is an erc1820 registry contract (if false, skips Erc777 validation)
- tries to fetch the erc1820 abi (if fails, skips callbacks validation)
- if any validation is skipped, a warning log is printed

3. validatePriceFeeds renamed to validateTickers

4. validateTickers is called in initOracleConfigForTokens