### PR TITLE
Add position value to reader position info

### DIFF
--- a/contracts/reader/ReaderPositionUtils.sol
+++ b/contracts/reader/ReaderPositionUtils.sol
@@ -287,7 +287,7 @@ library ReaderPositionUtils {
             positionInfo.basePnlUsd +
             positionInfo.executionPriceResult.totalImpactUsd -
             // substracted as int256 to avoid underflow operating in uint256 space if cost is greater than collateral amount
-            (positionInfo.fees.totalCostAmount * cache.collateralTokenPrice.min).toInt256();
+            (positionInfo.fees.totalCostAmount * cache.collateralTokenPrice.max).toInt256();
 
         return positionInfo;
     }

--- a/scripts/generateMarketClaimsData.ts
+++ b/scripts/generateMarketClaimsData.ts
@@ -216,7 +216,7 @@ async function analyzePositions(
       const collateralUsd = collateralAmount.mul(collateralTokenPrice);
 
       // Use calculated values from positionInfo
-      const pnlUsd = positionInfo.pnlAfterPriceImpactUsd || bigNumberify(0); // Real-time PnL including price impact at close
+      const pnlUsd = positionInfo.executionPriceResult.priceImpactUsd.add(positionInfo.basePnlUsd) || bigNumberify(0); // Real-time PnL including price impact at close
 
       // Convert total fees from tokens to USD
       // totalCostAmount is in collateral tokens

--- a/scripts/generateMarketClaimsData.ts
+++ b/scripts/generateMarketClaimsData.ts
@@ -216,7 +216,9 @@ async function analyzePositions(
       const collateralUsd = collateralAmount.mul(collateralTokenPrice);
 
       // Use calculated values from positionInfo
-      const pnlUsd = positionInfo.executionPriceResult.priceImpactUsd.add(positionInfo.basePnlUsd) || bigNumberify(0); // Real-time PnL including price impact at close
+      const priceImpactUsd = positionInfo.executionPriceResult.priceImpactUsd || bigNumberify(0);
+      const basePnlUsd = positionInfo.basePnlUsd || bigNumberify(0);
+      const pnlUsd = priceImpactUsd.add(basePnlUsd); // Real-time PnL including price impact at close
 
       // Convert total fees from tokens to USD
       // totalCostAmount is in collateral tokens

--- a/test/reader/ReaderPositionValueInUsd.ts
+++ b/test/reader/ReaderPositionValueInUsd.ts
@@ -1,0 +1,100 @@
+import { expect } from "chai";
+
+import { deployFixture } from "../../utils/fixture";
+import { expandDecimals, decimalToFloat } from "../../utils/math";
+import { handleDeposit } from "../../utils/deposit";
+import { OrderType, handleOrder } from "../../utils/order";
+import { getPositionKeys } from "../../utils/position";
+import * as keys from "../../utils/keys";
+
+describe("Reader.PositionValueInUsd", () => {
+  let fixture;
+  let user0;
+  let reader, dataStore, referralStorage;
+  let ethUsdMarket, wnt;
+
+  beforeEach(async () => {
+    fixture = await deployFixture();
+    ({ user0 } = fixture.accounts);
+    ({ reader, dataStore, referralStorage, ethUsdMarket, wnt } = fixture.contracts);
+
+    await handleDeposit(fixture, {
+      create: {
+        market: ethUsdMarket,
+        longTokenAmount: expandDecimals(1000, 18),
+        shortTokenAmount: expandDecimals(1000 * 5000, 6),
+      },
+    });
+  });
+
+  it("should get positionValueInUsd", async () => {
+    await dataStore.setUint(keys.positionImpactFactorKey(ethUsdMarket.marketToken, true), decimalToFloat(5, 9));
+    await dataStore.setUint(keys.positionImpactFactorKey(ethUsdMarket.marketToken, false), decimalToFloat(1, 8));
+    await dataStore.setUint(keys.positionImpactExponentFactorKey(ethUsdMarket.marketToken, true), decimalToFloat(2, 0));
+    await dataStore.setUint(
+      keys.positionImpactExponentFactorKey(ethUsdMarket.marketToken, false),
+      decimalToFloat(2, 0)
+    );
+
+    const initialCollateralAmount = expandDecimals(10, 18);
+
+    const params = {
+      account: user0,
+      market: ethUsdMarket,
+      initialCollateralToken: wnt,
+      initialCollateralDeltaAmount: initialCollateralAmount,
+      swapPath: [],
+      sizeDeltaUsd: decimalToFloat(200 * 1000),
+      acceptablePrice: expandDecimals(5050, 12),
+      executionFee: expandDecimals(1, 15),
+      minOutputAmount: expandDecimals(50000, 6),
+      orderType: OrderType.MarketIncrease,
+      isLong: true,
+      shouldUnwrapNativeToken: false,
+    };
+
+    // increase long position, negative price impact
+    await handleOrder(fixture, {
+      create: params,
+      execute: {},
+    });
+
+    const positionKeys = await getPositionKeys(dataStore, 0, 10);
+
+    const prices = {
+      indexTokenPrice: {
+        min: expandDecimals(5000, 12),
+        max: expandDecimals(5000, 12),
+      },
+      longTokenPrice: {
+        min: expandDecimals(5000, 12),
+        max: expandDecimals(5000, 12),
+      },
+      shortTokenPrice: {
+        min: expandDecimals(1, 24),
+        max: expandDecimals(1, 24),
+      },
+    };
+
+    const positionInfo = await reader.getPositionInfo(
+      dataStore.address,
+      referralStorage.address,
+      positionKeys[positionKeys.length - 1],
+      prices,
+      decimalToFloat(200 * 1000), // sizeDeltaUsd
+      ethers.constants.AddressZero,
+      true // usePositionSizeAsSizeDeltaUsd
+    );
+
+    const price = expandDecimals(5000, 12);
+    const expected = initialCollateralAmount
+      .mul(price)
+      .sub(positionInfo.fees.totalCostAmount.mul(price))
+      .add(positionInfo.fees.funding.claimableLongTokenAmount.mul(price))
+      .add(positionInfo.fees.funding.claimableShortTokenAmount.mul(expandDecimals(1, 24)))
+      .add(positionInfo.executionPriceResult.totalImpactUsd)
+      .add(positionInfo.basePnlUsd);
+
+    expect(positionInfo.positionValueInUsd).to.eq(expected);
+  });
+});


### PR DESCRIPTION
- added new positionValueInUsd
- pnlAfterPriceImpactUsd field from Reader.getPositionInfo is removed due to contract size limit is hit when the new positionValueInUsd is added.
